### PR TITLE
[Feat] team-stadium 서비스 초기 설정

### DIFF
--- a/com.spoticket.team-stadium/.gitignore
+++ b/com.spoticket.team-stadium/.gitignore
@@ -35,3 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-prod.yml
+application-dev.yml
+
+
+

--- a/com.spoticket.team-stadium/build.gradle
+++ b/com.spoticket.team-stadium/build.gradle
@@ -1,48 +1,58 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.1'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.spoticket'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2024.0.0")
+    set('springCloudVersion', "2024.0.0")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.postgresql:postgresql'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.hibernate:hibernate-spatial:6.2.2.Final'
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
+
+    runtimeOnly 'org.postgresql:postgresql'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/common/ApiResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/common/ApiResponse.java
@@ -1,0 +1,12 @@
+package com.spoticket.teamstadium.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(
+    int status,
+    String msg,
+    T data
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/common/BaseEntity.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/common/BaseEntity.java
@@ -1,0 +1,65 @@
+package com.spoticket.teamstadium.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+  @Column(name = "created_by", nullable = false, length = 100)
+  private String createdBy;
+
+  @Column(name = "updated_by", length = 100)
+  private String updatedBy;
+
+  @Column(name = "deleted_by", length = 100)
+  private String deletedBy;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  @Column(name = "is_deleted", nullable = false)
+  @ColumnDefault("false")
+  private boolean isDeleted;
+
+  // 생성
+  @PrePersist
+  public void createBase() {
+    this.createdAt = LocalDateTime.now();
+    this.createdBy = "temp_username"; // 임시데이터
+  }
+
+  // 수정
+  @PreUpdate
+  public void updateBase() {
+    this.updatedAt = LocalDateTime.now();
+    this.updatedBy = "temp_username"; // 임시데이터
+  }
+
+  // 삭제
+  public void deleteBase(String username) {
+    this.isDeleted = true;
+    this.deletedAt = LocalDateTime.now();
+    this.deletedBy = username;
+  }
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/common/PaginatedResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/common/PaginatedResponse.java
@@ -1,0 +1,23 @@
+package com.spoticket.teamstadium.common;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PaginatedResponse<T>(
+    Long totalElements,
+    Integer totalPages,
+    Integer currentPage,
+    Integer pageSize,
+    List<T> content
+) {
+
+  public static <T> PaginatedResponse<T> of(Page<T> page) {
+    return new PaginatedResponse<>(
+        page.getTotalElements(),
+        page.getTotalPages(),
+        page.getNumber(),
+        page.getSize(),
+        page.getContent()
+    );
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/FavTeam.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/FavTeam.java
@@ -1,0 +1,38 @@
+package com.spoticket.teamstadium.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity(name = "P_FAV_TEAMS")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class FavTeam {
+
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  @Column(updatable = false, nullable = false)
+  private UUID favId;
+
+  @ManyToOne
+  @JoinColumn(name = "team_id", nullable = false)
+  private Team team;
+
+  @Column(nullable = false)
+  private UUID userId;
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/FavTeam.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/FavTeam.java
@@ -11,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
 
 @Entity(name = "P_FAV_TEAMS")
@@ -19,7 +18,6 @@ import org.hibernate.annotations.UuidGenerator;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 public class FavTeam {
 
   @Id

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Seat.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Seat.java
@@ -14,7 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
 
 @Entity(name = "P_SEATS")
@@ -22,7 +21,6 @@ import org.hibernate.annotations.UuidGenerator;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 public class Seat extends BaseEntity {
 
   @Id

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Seat.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Seat.java
@@ -1,0 +1,78 @@
+package com.spoticket.teamstadium.domain;
+
+
+import com.spoticket.teamstadium.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.Min;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity(name = "P_SEATS")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class Seat extends BaseEntity {
+
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  @Column(updatable = false, nullable = false)
+  private UUID seatId;
+
+  @Column(nullable = false)
+  private String section;
+
+  @Min(0)
+  @Column(nullable = false)
+  private Long quantity;
+
+  @Min(0)
+  @Column(nullable = false)
+  private Integer price;
+
+  @ManyToOne
+  @JoinColumn(name = "stadium_id", nullable = false)
+  private Stadium stadium;
+
+  public static Seat create(
+      String section,
+      long quantity,
+      Integer price,
+      Stadium stadium
+  ) {
+    return Seat.builder()
+        .section(section)
+        .quantity(quantity)
+        .price(price)
+        .stadium(stadium)
+        .build();
+  }
+
+  public void update(
+      String section,
+      Long quantity,
+      Integer price
+  ) {
+    if (section != null) {
+      this.section = section;
+    }
+    if (quantity != null) {
+      this.quantity = quantity;
+    }
+    if (price != null) {
+      this.price = price;
+    }
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Stadium.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Stadium.java
@@ -14,7 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
 import org.locationtech.jts.geom.Point;
 
@@ -23,7 +22,6 @@ import org.locationtech.jts.geom.Point;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 public class Stadium extends BaseEntity {
 
   @Id

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Stadium.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Stadium.java
@@ -1,0 +1,90 @@
+package com.spoticket.teamstadium.domain;
+
+import com.spoticket.teamstadium.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+import org.locationtech.jts.geom.Point;
+
+@Entity(name = "P_STADIUM")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class Stadium extends BaseEntity {
+
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  @Column(updatable = false, nullable = false)
+  private UUID stadiumId;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private String address;
+
+  @Column(nullable = false)
+  private Point latLng;
+
+  private String seatImage;
+
+  private String description;
+
+  @OneToMany(mappedBy = "stadium", fetch = FetchType.LAZY)
+  private List<Seat> seats = new ArrayList<>();
+
+  public static Stadium create(
+      String name,
+      String address,
+      Point latLng,
+      String seatImage,
+      String description
+  ) {
+    return Stadium.builder()
+        .name(name)
+        .address(address)
+        .latLng(latLng)
+        .seatImage(seatImage)
+        .description(description)
+        .build();
+  }
+
+  public void update(
+      String name,
+      String address,
+      String seatImage,
+      String description,
+      Point latLng
+  ) {
+    if (name != null) {
+      this.name = name;
+    }
+    if (address != null) {
+      this.address = address;
+    }
+    if (seatImage != null) {
+      this.seatImage = seatImage;
+    }
+    if (description != null) {
+      this.description = description;
+    }
+    if (latLng != null) {
+      this.latLng = latLng;
+    }
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Team.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Team.java
@@ -10,7 +10,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.UuidGenerator;
 
 @Entity(name = "P_TEAMS")
@@ -18,7 +17,6 @@ import org.hibernate.annotations.UuidGenerator;
 @AllArgsConstructor
 @Builder
 @Getter
-@Setter
 public class Team extends BaseEntity {
 
   @Id

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Team.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/Team.java
@@ -1,0 +1,85 @@
+package com.spoticket.teamstadium.domain;
+
+import com.spoticket.teamstadium.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+
+@Entity(name = "P_TEAMS")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Setter
+public class Team extends BaseEntity {
+
+  @Id
+  @GeneratedValue
+  @UuidGenerator
+  @Column(updatable = false, nullable = false)
+  private UUID teamId;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private TeamCategoryEnum category;
+
+  private String description;
+
+  private String profile;
+
+  private String homeLink;
+
+  private String snsLink;
+
+  public static Team create(
+      String name,
+      TeamCategoryEnum category,
+      String description,
+      String profile,
+      String homeLink,
+      String snsLink
+  ) {
+    return Team.builder()
+        .name(name)
+        .category(category)
+        .description(description)
+        .profile(profile)
+        .homeLink(homeLink)
+        .snsLink(snsLink)
+        .build();
+  }
+
+  public void update(
+      String name,
+      String description,
+      String profile,
+      String homeLink,
+      String snsLink
+  ) {
+    if (name != null) {
+      this.name = name;
+    }
+    if (description != null) {
+      this.description = description;
+    }
+    if (profile != null) {
+      this.profile = profile;
+    }
+    if (homeLink != null) {
+      this.homeLink = homeLink;
+    }
+    if (snsLink != null) {
+      this.snsLink = snsLink;
+    }
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/TeamCategoryEnum.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/TeamCategoryEnum.java
@@ -1,0 +1,14 @@
+package com.spoticket.teamstadium.domain;
+
+public enum TeamCategoryEnum {
+
+  HANDBALL,
+  ICE_HOCKEY,
+  SOCCER,
+  BASEBALL,
+  BASKETBALL,
+  VOLLEYBALL,
+  OTHER,
+  E_SPORTS
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/SeatCreateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/SeatCreateRequest.java
@@ -1,0 +1,15 @@
+package com.spoticket.teamstadium.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record SeatCreateRequest(
+    @NotNull UUID stadiumId,
+    @NotNull UUID gameId,
+    @NotNull String section,
+    @NotNull @Min(0) Long quantity,
+    @NotNull @Min(0) Integer price
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/SeatUpdateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/SeatUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.spoticket.teamstadium.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SeatUpdateRequest(
+    @NotNull String section,
+    @NotNull Long quantity,
+    @NotNull Integer price
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/StadiumCreateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/StadiumCreateRequest.java
@@ -1,0 +1,15 @@
+package com.spoticket.teamstadium.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record StadiumCreateRequest(
+
+    @NotNull String name,
+    @NotNull String address,
+    @NotNull double lat,
+    @NotNull double lng,
+    String seatImage,
+    String description
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/TeamCreateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/TeamCreateRequest.java
@@ -1,0 +1,17 @@
+package com.spoticket.teamstadium.dto.request;
+
+import com.spoticket.teamstadium.domain.TeamCategoryEnum;
+import jakarta.validation.constraints.NotNull;
+
+public record TeamCreateRequest(
+
+    @NotNull String name,
+    @NotNull TeamCategoryEnum category,
+    @NotNull String description,
+    String profile,
+    String homeLink,
+    String snsLink
+
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/TeamUpdateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/request/TeamUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.spoticket.teamstadium.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TeamUpdateRequest(
+
+    @NotNull String name,
+    @NotNull String description,
+    String profile,
+    String homeLink,
+    String snsLink
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/GameReadResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/GameReadResponse.java
@@ -1,0 +1,16 @@
+package com.spoticket.teamstadium.dto.response;
+
+import com.spoticket.teamstadium.domain.TeamCategoryEnum;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record GameReadResponse(
+    UUID gameId,
+    String title,
+    LocalDateTime startTime,
+    TeamCategoryEnum sport,
+    String league
+
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/SeatListReadResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/SeatListReadResponse.java
@@ -1,0 +1,21 @@
+package com.spoticket.teamstadium.dto.response;
+
+import com.spoticket.teamstadium.domain.Seat;
+import java.util.UUID;
+
+public record SeatListReadResponse(
+    UUID seatId,
+    String section,
+    Long quantity,
+    Integer price
+) {
+
+  public static SeatListReadResponse from(Seat seat) {
+    return new SeatListReadResponse(
+        seat.getSeatId(),
+        seat.getSection(),
+        seat.getQuantity(),
+        seat.getPrice()
+    );
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/StadiumInfoResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/StadiumInfoResponse.java
@@ -1,0 +1,23 @@
+package com.spoticket.teamstadium.dto.response;
+
+import com.spoticket.teamstadium.domain.Stadium;
+import java.util.UUID;
+
+public record StadiumInfoResponse(
+    UUID stadiumId,
+    String name,
+    String address,
+    String seatImage,
+    String description
+) {
+
+  public static StadiumInfoResponse from(Stadium stadium) {
+    return new StadiumInfoResponse(
+        stadium.getStadiumId(),
+        stadium.getName(),
+        stadium.getAddress(),
+        stadium.getSeatImage(),
+        stadium.getDescription()
+    );
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/StadiumListReadResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/StadiumListReadResponse.java
@@ -1,0 +1,23 @@
+package com.spoticket.teamstadium.dto.response;
+
+import com.spoticket.teamstadium.domain.Stadium;
+import java.util.UUID;
+
+public record StadiumListReadResponse(
+    UUID stadiumId,
+    String name,
+    String address,
+    String seatImage,
+    String description
+) {
+
+  public static StadiumListReadResponse from(Stadium stadium) {
+    return new StadiumListReadResponse(
+        stadium.getStadiumId(),
+        stadium.getName(),
+        stadium.getAddress(),
+        stadium.getSeatImage(),
+        stadium.getDescription()
+    );
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/StadiumReadResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/StadiumReadResponse.java
@@ -1,0 +1,10 @@
+package com.spoticket.teamstadium.dto.response;
+
+import java.util.List;
+
+public record StadiumReadResponse(
+    StadiumInfoResponse stadium,
+    List<GameReadResponse> games
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/TeamInfoResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/TeamInfoResponse.java
@@ -1,0 +1,32 @@
+package com.spoticket.teamstadium.dto.response;
+
+import com.spoticket.teamstadium.domain.Team;
+import com.spoticket.teamstadium.domain.TeamCategoryEnum;
+import java.util.UUID;
+
+public record TeamInfoResponse(
+    UUID teamId,
+    String name,
+    TeamCategoryEnum category,
+    String description,
+    String profile,
+    String homeLink,
+    String snsLink,
+    Integer favCnt,
+    Boolean isFavorite
+) {
+
+  public static TeamInfoResponse from(Team team, Integer favCnt, boolean isFav) {
+    return new TeamInfoResponse(
+        team.getTeamId(),
+        team.getName(),
+        team.getCategory(),
+        team.getDescription(),
+        team.getProfile(),
+        team.getHomeLink(),
+        team.getSnsLink(),
+        favCnt,
+        isFav
+    );
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/TeamListReadResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/TeamListReadResponse.java
@@ -1,0 +1,22 @@
+package com.spoticket.teamstadium.dto.response;
+
+import com.spoticket.teamstadium.domain.Team;
+import com.spoticket.teamstadium.domain.TeamCategoryEnum;
+import java.util.UUID;
+
+public record TeamListReadResponse(
+
+    UUID teamId,
+    String name,
+    TeamCategoryEnum category
+) {
+
+  public static TeamListReadResponse from(Team team) {
+    return new TeamListReadResponse(
+        team.getTeamId(),
+        team.getName(),
+        team.getCategory()
+    );
+  }
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/TeamReadResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/dto/response/TeamReadResponse.java
@@ -1,0 +1,10 @@
+package com.spoticket.teamstadium.dto.response;
+
+import java.util.List;
+
+public record TeamReadResponse(
+    TeamInfoResponse team,
+    List<GameReadResponse> games
+) {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/FavTeamRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/FavTeamRepository.java
@@ -1,0 +1,12 @@
+package com.spoticket.teamstadium.infrastructure;
+
+
+import com.spoticket.teamstadium.domain.FavTeam;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FavTeamRepository extends JpaRepository<FavTeam, UUID> {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/SeatRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/SeatRepository.java
@@ -1,0 +1,12 @@
+package com.spoticket.teamstadium.infrastructure;
+
+
+import com.spoticket.teamstadium.domain.Seat;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SeatRepository extends JpaRepository<Seat, UUID> {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/StadiumRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/StadiumRepository.java
@@ -1,0 +1,12 @@
+package com.spoticket.teamstadium.infrastructure;
+
+
+import com.spoticket.teamstadium.domain.Stadium;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StadiumRepository extends JpaRepository<Stadium, UUID> {
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/TeamRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/TeamRepository.java
@@ -1,0 +1,12 @@
+package com.spoticket.teamstadium.infrastructure;
+
+
+import com.spoticket.teamstadium.domain.Team;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TeamRepository extends JpaRepository<Team, UUID> {
+
+}

--- a/com.spoticket.team-stadium/src/main/resources/application.yml
+++ b/com.spoticket.team-stadium/src/main/resources/application.yml
@@ -1,3 +1,0 @@
-spring:
-  profiles:
-    active: dev

--- a/com.spoticket.team-stadium/src/main/resources/application.yml
+++ b/com.spoticket.team-stadium/src/main/resources/application.yml
@@ -1,11 +1,3 @@
 spring:
-  application:
-    name: team-stadium
-
-server:
-  port: 8082
-
-eureka:
-  client:
-    service-url:
-      defaultZone: http://localhost:8761/eureka
+  profiles:
+    active: dev


### PR DESCRIPTION
# [Feat] team-stadium 서비스 초기 설정

## 개요
team-stadium 서비스 초기 설정

## 변경 사항

- gitignore 수정
- 의존성 설정
- BaseEntity 작성
- 팀, 경기장, 좌석 엔티티 작성
- jpa repository 작성
- 공통 응답 작성
- 팀, 경기장, 좌석 기능 관련 dto 작성
- 
## 스크린샷 (선택사항)

## 특이 사항

resolved: #8 
