### PR TITLE
[Feat] 경기장 생성 및 조회 기능 구현

### DIFF
--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/StadiumCreateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/StadiumCreateRequest.java
@@ -1,12 +1,11 @@
 package com.spoticket.teamstadium.application.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record StadiumCreateRequest(
 
-    @NotBlank @Size(max = 100) String name,
+    @NotNull @Size(max = 100) String name,
     @NotNull @Size(max = 200) String address,
     @NotNull double lat,
     @NotNull double lng,

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/StadiumCreateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/StadiumCreateRequest.java
@@ -1,14 +1,16 @@
 package com.spoticket.teamstadium.application.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record StadiumCreateRequest(
 
-    @NotNull String name,
-    @NotNull String address,
+    @NotBlank @Size(max = 100) String name,
+    @NotNull @Size(max = 200) String address,
     @NotNull double lat,
     @NotNull double lng,
-    String seatImage,
+    @Size(max = 500) String seatImage,
     String description
 ) {
 

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/TeamCreateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/TeamCreateRequest.java
@@ -9,7 +9,7 @@ public record TeamCreateRequest(
 
     @NotBlank @Size(max = 100) String name,
     @NotNull TeamCategoryEnum category,
-    @NotBlank @Size(max = 500) String description,
+    String description,
     @Size(max = 500) String profile,
     @Size(max = 300) String homeLink,
     @Size(max = 300) String snsLink

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/TeamCreateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/TeamCreateRequest.java
@@ -1,13 +1,12 @@
 package com.spoticket.teamstadium.application.dto.request;
 
 import com.spoticket.teamstadium.domain.model.TeamCategoryEnum;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record TeamCreateRequest(
 
-    @NotBlank @Size(max = 100) String name,
+    @NotNull @Size(max = 100) String name,
     @NotNull TeamCategoryEnum category,
     String description,
     @Size(max = 500) String profile,

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/TeamUpdateRequest.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/request/TeamUpdateRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Size;
 
 public record TeamUpdateRequest(
     @Size(max = 100) String name,
-    @Size(max = 500) String description,
+    String description,
     @Size(max = 500) String profile,
     @Size(max = 300) String homeLink,
     @Size(max = 300) String snsLink

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/response/StadiumListReadResponse.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/dto/response/StadiumListReadResponse.java
@@ -6,18 +6,14 @@ import java.util.UUID;
 public record StadiumListReadResponse(
     UUID stadiumId,
     String name,
-    String address,
-    String seatImage,
-    String description
+    String address
 ) {
 
   public static StadiumListReadResponse from(Stadium stadium) {
     return new StadiumListReadResponse(
         stadium.getStadiumId(),
         stadium.getName(),
-        stadium.getAddress(),
-        stadium.getSeatImage(),
-        stadium.getDescription()
+        stadium.getAddress()
     );
   }
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/service/StadiumService.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/service/StadiumService.java
@@ -3,6 +3,7 @@ package com.spoticket.teamstadium.application.service;
 import com.spoticket.teamstadium.application.dto.request.StadiumCreateRequest;
 import com.spoticket.teamstadium.application.dto.response.GameReadResponse;
 import com.spoticket.teamstadium.application.dto.response.StadiumInfoResponse;
+import com.spoticket.teamstadium.application.dto.response.StadiumListReadResponse;
 import com.spoticket.teamstadium.application.dto.response.StadiumReadResponse;
 import com.spoticket.teamstadium.domain.model.Stadium;
 import com.spoticket.teamstadium.domain.repository.StadiumRepository;
@@ -10,6 +11,7 @@ import com.spoticket.teamstadium.exception.BusinessException;
 import com.spoticket.teamstadium.exception.ErrorCode;
 import com.spoticket.teamstadium.exception.NotFoundException;
 import com.spoticket.teamstadium.global.dto.ApiResponse;
+import com.spoticket.teamstadium.global.dto.PaginatedResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -17,6 +19,9 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -58,6 +63,15 @@ public class StadiumService {
     List<GameReadResponse> games = null;
     StadiumReadResponse response = new StadiumReadResponse(stadiumInfo, games);
     return new ApiResponse<>(200, "조회 완료", response);
+  }
+
+  // 경기장 목록 조회
+  public PaginatedResponse<StadiumListReadResponse> getStadiums(int page, int size) {
+    Pageable pageable = PageRequest.of(page, size);
+    Page<Stadium> stadiums = stadiumRepository.findAllByIsDeletedFalse(pageable);
+
+    Page<StadiumListReadResponse> response = stadiums.map(StadiumListReadResponse::from);
+    return PaginatedResponse.of(response);
   }
 
   public Stadium getStadiumById(UUID stadiumId) {

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/service/StadiumService.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/service/StadiumService.java
@@ -38,9 +38,9 @@ public class StadiumService {
         request.description()
     );
 
-    stadiumRepository.save(stadium);
+    Stadium savedStadium = stadiumRepository.save(stadium);
 
-    Map<String, UUID> response = Map.of("stadiumId", stadium.getStadiumId());
+    Map<String, UUID> response = Map.of("stadiumId", savedStadium.getStadiumId());
     return new ApiResponse<>(200, "등록 완료", response);
   }
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/service/StadiumService.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/service/StadiumService.java
@@ -1,11 +1,16 @@
 package com.spoticket.teamstadium.application.service;
 
 import com.spoticket.teamstadium.application.dto.request.StadiumCreateRequest;
+import com.spoticket.teamstadium.application.dto.response.GameReadResponse;
+import com.spoticket.teamstadium.application.dto.response.StadiumInfoResponse;
+import com.spoticket.teamstadium.application.dto.response.StadiumReadResponse;
 import com.spoticket.teamstadium.domain.model.Stadium;
 import com.spoticket.teamstadium.domain.repository.StadiumRepository;
 import com.spoticket.teamstadium.exception.BusinessException;
 import com.spoticket.teamstadium.exception.ErrorCode;
+import com.spoticket.teamstadium.exception.NotFoundException;
 import com.spoticket.teamstadium.global.dto.ApiResponse;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -42,5 +47,22 @@ public class StadiumService {
 
     Map<String, UUID> response = Map.of("stadiumId", savedStadium.getStadiumId());
     return new ApiResponse<>(200, "등록 완료", response);
+  }
+
+  // 경기장 단일 조회
+  public ApiResponse<StadiumReadResponse> getStadiumInfo(UUID stadiumId) {
+
+    Stadium stadium = getStadiumById(stadiumId);
+    StadiumInfoResponse stadiumInfo = StadiumInfoResponse.from(stadium);
+    // 경기장 관련 게임 정보 조회 메서드 호출 필요
+    List<GameReadResponse> games = null;
+    StadiumReadResponse response = new StadiumReadResponse(stadiumInfo, games);
+    return new ApiResponse<>(200, "조회 완료", response);
+  }
+
+  public Stadium getStadiumById(UUID stadiumId) {
+    return stadiumRepository.findByStadiumIdAndIsDeletedFalse(stadiumId)
+        .orElseThrow(() -> new NotFoundException(ErrorCode.STADIUM_NOT_FOUND));
+
   }
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/service/StadiumService.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/application/service/StadiumService.java
@@ -1,0 +1,46 @@
+package com.spoticket.teamstadium.application.service;
+
+import com.spoticket.teamstadium.application.dto.request.StadiumCreateRequest;
+import com.spoticket.teamstadium.domain.model.Stadium;
+import com.spoticket.teamstadium.domain.repository.StadiumRepository;
+import com.spoticket.teamstadium.exception.BusinessException;
+import com.spoticket.teamstadium.exception.ErrorCode;
+import com.spoticket.teamstadium.global.dto.ApiResponse;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StadiumService {
+
+  private final StadiumRepository stadiumRepository;
+
+  public ApiResponse<Map<String, UUID>> createStadium(StadiumCreateRequest request) {
+    // 요청자 권한 체크
+
+    // 경기장 이름 중복 체크
+    if (stadiumRepository.findByNameAndIsDeletedFalse(request.name()).isPresent()) {
+      throw new BusinessException(ErrorCode.DUPLICATE_STADIUM_NAME);
+    }
+
+    GeometryFactory geometryFactory = new GeometryFactory();
+    Point latLng = geometryFactory.createPoint(new Coordinate(request.lng(), request.lat()));
+    Stadium stadium = Stadium.create(
+        request.name(),
+        request.address(),
+        latLng,
+        request.seatImage(),
+        request.description()
+    );
+
+    stadiumRepository.save(stadium);
+
+    Map<String, UUID> response = Map.of("stadiumId", stadium.getStadiumId());
+    return new ApiResponse<>(200, "등록 완료", response);
+  }
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/model/Stadium.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/model/Stadium.java
@@ -46,6 +46,7 @@ public class Stadium extends BaseEntity {
   private String description;
 
   @OneToMany(mappedBy = "stadium", fetch = FetchType.LAZY)
+  @Builder.Default
   private List<Seat> seats = new ArrayList<>();
 
   public static Stadium create(

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/model/Stadium.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/model/Stadium.java
@@ -30,17 +30,19 @@ public class Stadium extends BaseEntity {
   @Column(updatable = false, nullable = false)
   private UUID stadiumId;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 100)
   private String name;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 200)
   private String address;
 
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "geometry(Point, 4326)")
   private Point latLng;
 
+  @Column(length = 500)
   private String seatImage;
 
+  @Column(columnDefinition = "TEXT")
   private String description;
 
   @OneToMany(mappedBy = "stadium", fetch = FetchType.LAZY)

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/model/Team.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/model/Team.java
@@ -72,9 +72,7 @@ public class Team extends BaseEntity {
     if (name != null && StringUtils.hasText(name) && name.length() <= 100) {
       this.name = name;
     }
-    if (description == null || description.length() <= 500) {
-      this.description = description;
-    }
+    this.description = description;
     if (profile == null || profile.length() <= 500) {
       this.profile = profile;
     }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/repository/StadiumRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/repository/StadiumRepository.java
@@ -3,6 +3,8 @@ package com.spoticket.teamstadium.domain.repository;
 import com.spoticket.teamstadium.domain.model.Stadium;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface StadiumRepository {
 
@@ -11,4 +13,6 @@ public interface StadiumRepository {
   Stadium save(Stadium stadium);
 
   Optional<Stadium> findByStadiumIdAndIsDeletedFalse(UUID stadiumId);
+
+  Page<Stadium> findAllByIsDeletedFalse(Pageable pageable);
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/repository/StadiumRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/repository/StadiumRepository.java
@@ -1,5 +1,11 @@
 package com.spoticket.teamstadium.domain.repository;
 
+import com.spoticket.teamstadium.domain.model.Stadium;
+import java.util.Optional;
+
 public interface StadiumRepository {
 
+  Optional<Stadium> findByNameAndIsDeletedFalse(String name);
+
+  Stadium save(Stadium stadium);
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/repository/StadiumRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/repository/StadiumRepository.java
@@ -2,10 +2,13 @@ package com.spoticket.teamstadium.domain.repository;
 
 import com.spoticket.teamstadium.domain.model.Stadium;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface StadiumRepository {
 
   Optional<Stadium> findByNameAndIsDeletedFalse(String name);
 
   Stadium save(Stadium stadium);
+
+  Optional<Stadium> findByStadiumIdAndIsDeletedFalse(UUID stadiumId);
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/repository/TeamRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/domain/repository/TeamRepository.java
@@ -7,14 +7,12 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface TeamRepository {
 
+
   Team save(Team team);
 
-  @Query("SELECT t FROM p_teams t WHERE REPLACE(t.name, ' ', '') = REPLACE(:name, ' ', '') AND t.isDeleted = false")
   Optional<Team> findByNameAndIsDeletedFalse(String name);
 
   Optional<Team> findByTeamIdAndIsDeletedFalse(UUID teamId);
@@ -23,7 +21,5 @@ public interface TeamRepository {
 
   Page<Team> findAllByIsDeletedFalse(Pageable pageable);
 
-  @Query("SELECT t FROM p_teams t WHERE t.teamId IN :teamIds AND t.isDeleted = false")
-  Page<Team> findAllByTeamIdInAndIsDeletedFalse(
-      @Param("teamIds") List<UUID> teamIds, Pageable pageable);
+  Page<Team> findAllByTeamIdInAndIsDeletedFalse(List<UUID> teamIds, Pageable pageable);
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/exception/ErrorCode.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/exception/ErrorCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum ErrorCode {
 
   DUPLICATE_TEAM_NAME(400, "중복된 팀명입니다"),
+  DUPLICATE_STADIUM_NAME(400, "중복된 경기장 이름입니다"),
   TEAM_NOT_FOUND(404, "해당하는 팀이 없습니다"),
   NOT_FOUND(404, "요청한 리소스를 찾을 수 없습니다"),
   GAME_DATA_FETCH_FAILED(500, "게임 데이터를 가져오지 못했습니다."),

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/exception/ErrorCode.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/exception/ErrorCode.java
@@ -8,6 +8,7 @@ public enum ErrorCode {
   DUPLICATE_TEAM_NAME(400, "중복된 팀명입니다"),
   DUPLICATE_STADIUM_NAME(400, "중복된 경기장 이름입니다"),
   TEAM_NOT_FOUND(404, "해당하는 팀이 없습니다"),
+  STADIUM_NOT_FOUND(404, "해당하는 경기장이 없습니다"),
   NOT_FOUND(404, "요청한 리소스를 찾을 수 없습니다"),
   GAME_DATA_FETCH_FAILED(500, "게임 데이터를 가져오지 못했습니다."),
   SERVER_ERROR(500, "서버 에러가 발생했습니다");

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/repository/jpa/JpaStadiumRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/repository/jpa/JpaStadiumRepository.java
@@ -2,11 +2,17 @@ package com.spoticket.teamstadium.infrastructure.repository.jpa;
 
 
 import com.spoticket.teamstadium.domain.model.Stadium;
+import com.spoticket.teamstadium.domain.repository.StadiumRepository;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface JpaStadiumRepository extends JpaRepository<Stadium, UUID> {
+public interface JpaStadiumRepository extends StadiumRepository, JpaRepository<Stadium, UUID> {
 
+  @Query("SELECT st FROM p_stadiums st WHERE REPLACE(st.name, ' ', '') = REPLACE(:name, ' ', '') AND st.isDeleted = false")
+  Optional<Stadium> findByNameAndIsDeletedFalse(@Param("name") String name);
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/repository/jpa/JpaTeamRepository.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/infrastructure/repository/jpa/JpaTeamRepository.java
@@ -3,12 +3,25 @@ package com.spoticket.teamstadium.infrastructure.repository.jpa;
 
 import com.spoticket.teamstadium.domain.model.Team;
 import com.spoticket.teamstadium.domain.repository.TeamRepository;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JpaTeamRepository extends TeamRepository, JpaRepository<Team, UUID> {
 
+  @Query("SELECT t FROM p_teams t WHERE REPLACE(t.name, ' ', '') = REPLACE(:name, ' ', '') AND t.isDeleted = false")
+  Optional<Team> findByNameAndIsDeletedFalse(@Param("name") String name);
 
+  @Query("SELECT t FROM p_teams t WHERE t.teamId IN :teamIds AND t.isDeleted = false")
+  Page<Team> findAllByTeamIdInAndIsDeletedFalse(
+      @Param("teamIds") List<UUID> teamIds,
+      Pageable pageable
+  );
 }

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/presentation/StadiumController.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/presentation/StadiumController.java
@@ -1,0 +1,30 @@
+package com.spoticket.teamstadium.presentation;
+
+import com.spoticket.teamstadium.application.dto.request.StadiumCreateRequest;
+import com.spoticket.teamstadium.application.service.StadiumService;
+import com.spoticket.teamstadium.global.dto.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/stadiums")
+@RequiredArgsConstructor
+public class StadiumController {
+
+  private final StadiumService stadiumService;
+
+  // 경기장 정보 등록
+  @PostMapping
+  public ApiResponse<Map<String, UUID>> createStadium(
+      @Valid @RequestBody StadiumCreateRequest request
+  ) {
+    return stadiumService.createStadium(request);
+  }
+
+}

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/presentation/StadiumController.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/presentation/StadiumController.java
@@ -1,9 +1,11 @@
 package com.spoticket.teamstadium.presentation;
 
 import com.spoticket.teamstadium.application.dto.request.StadiumCreateRequest;
+import com.spoticket.teamstadium.application.dto.response.StadiumListReadResponse;
 import com.spoticket.teamstadium.application.dto.response.StadiumReadResponse;
 import com.spoticket.teamstadium.application.service.StadiumService;
 import com.spoticket.teamstadium.global.dto.ApiResponse;
+import com.spoticket.teamstadium.global.dto.PaginatedResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
 import java.util.UUID;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,6 +39,17 @@ public class StadiumController {
       @PathVariable UUID stadiumId
   ) {
     return stadiumService.getStadiumInfo(stadiumId);
+  }
+
+  // 경기장 목록 조회
+  @GetMapping
+  public ApiResponse<PaginatedResponse<StadiumListReadResponse>> getStadiums(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size
+  ) {
+    PaginatedResponse<StadiumListReadResponse> response = stadiumService
+        .getStadiums(page, size);
+    return new ApiResponse<>(200, "조회 완료", response);
   }
 
 

--- a/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/presentation/StadiumController.java
+++ b/com.spoticket.team-stadium/src/main/java/com/spoticket/teamstadium/presentation/StadiumController.java
@@ -1,12 +1,15 @@
 package com.spoticket.teamstadium.presentation;
 
 import com.spoticket.teamstadium.application.dto.request.StadiumCreateRequest;
+import com.spoticket.teamstadium.application.dto.response.StadiumReadResponse;
 import com.spoticket.teamstadium.application.service.StadiumService;
 import com.spoticket.teamstadium.global.dto.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +29,14 @@ public class StadiumController {
   ) {
     return stadiumService.createStadium(request);
   }
+
+  // 경기장 단일 조회
+  @GetMapping("/{stadiumId}")
+  public ApiResponse<StadiumReadResponse> getStadiumInfo(
+      @PathVariable UUID stadiumId
+  ) {
+    return stadiumService.getStadiumInfo(stadiumId);
+  }
+
 
 }

--- a/com.spoticket.team-stadium/src/test/java/com/spoticket/teamstadium/factory/StadiumTestFactory.java
+++ b/com.spoticket.team-stadium/src/test/java/com/spoticket/teamstadium/factory/StadiumTestFactory.java
@@ -1,0 +1,26 @@
+package com.spoticket.teamstadium.factory;
+
+import com.spoticket.teamstadium.domain.model.Stadium;
+import java.util.UUID;
+import org.locationtech.jts.geom.Point;
+
+public class StadiumTestFactory {
+
+  public static Stadium createWithId(
+      UUID stadiumId,
+      String name,
+      String address,
+      Point latLng,
+      String seatImage,
+      String descripion
+  ) {
+    return Stadium.builder()
+        .stadiumId(stadiumId)
+        .name(name)
+        .address(address)
+        .latLng(latLng)
+        .seatImage(seatImage)
+        .description(descripion)
+        .build();
+  }
+}

--- a/com.spoticket.team-stadium/src/test/java/com/spoticket/teamstadium/service/StadiumServiceTest.java
+++ b/com.spoticket.team-stadium/src/test/java/com/spoticket/teamstadium/service/StadiumServiceTest.java
@@ -1,0 +1,114 @@
+package com.spoticket.teamstadium.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.spoticket.teamstadium.application.dto.request.StadiumCreateRequest;
+import com.spoticket.teamstadium.application.service.StadiumService;
+import com.spoticket.teamstadium.domain.model.Stadium;
+import com.spoticket.teamstadium.domain.repository.StadiumRepository;
+import com.spoticket.teamstadium.exception.BusinessException;
+import com.spoticket.teamstadium.exception.ErrorCode;
+import com.spoticket.teamstadium.factory.StadiumTestFactory;
+import com.spoticket.teamstadium.global.dto.ApiResponse;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+class StadiumServiceTest {
+
+  @Mock
+  private StadiumRepository stadiumRepository;
+
+  @InjectMocks
+  private StadiumService stadiumService;
+
+  // 경기장 생성 테스트
+  @Test
+  void createStadium_WhenStadiumNameIsDuplicate() {
+
+    // Given
+    String stadiumName = "exist name";
+    StadiumCreateRequest request = new StadiumCreateRequest(
+        stadiumName,
+        "sample address",
+        12.345,
+        45.678,
+        "https://seatImage.sample.com",
+        "sample description"
+    );
+
+    when(stadiumRepository.findByNameAndIsDeletedFalse(stadiumName)).thenReturn(
+        Optional.of(mock(Stadium.class)));
+
+    // When Then
+    assertThatThrownBy(() -> stadiumService.createStadium(request))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(ErrorCode.DUPLICATE_STADIUM_NAME.getMessage());
+
+    verify(stadiumRepository, times(1)).findByNameAndIsDeletedFalse(stadiumName);
+  }
+
+  @Test
+  void createTeam_WhenStadiumIsCreatedSuccessfully() {
+
+    // Given
+    String stadiumName = "new stadium";
+    StadiumCreateRequest request = new StadiumCreateRequest(
+        stadiumName,
+        "sample address",
+        12.345,
+        45.678,
+        "https://seatImage.sample.com",
+        "sample description"
+    );
+
+    when(stadiumRepository.findByNameAndIsDeletedFalse(stadiumName))
+        .thenReturn(Optional.empty());
+
+    UUID stadiumId = UUID.randomUUID();
+    Point latLng = new GeometryFactory().createPoint(new Coordinate(request.lng(), request.lat()));
+
+    Stadium mockStadium = StadiumTestFactory.createWithId(
+        stadiumId,
+        request.name(),
+        request.address(),
+        latLng,
+        request.seatImage(),
+        request.description()
+    );
+
+    when(stadiumRepository.save(any(Stadium.class))).thenReturn(mockStadium);
+
+    // When
+    ApiResponse<Map<String, UUID>> response = stadiumService.createStadium(request);
+
+    // Then
+    verify(stadiumRepository, times(1)).findByNameAndIsDeletedFalse(stadiumName);
+    verify(stadiumRepository, times(1)).save(any(Stadium.class));
+
+    assertNotNull(response);
+    assertEquals(200, response.code());
+    assertEquals("등록 완료", response.msg());
+    assertNotNull(response.data().get("stadiumId"));
+    assertEquals(stadiumId, response.data().get("stadiumId"));
+  }
+}
+
+

--- a/com.spoticket.team-stadium/src/test/java/com/spoticket/teamstadium/service/TeamServiceTest.java
+++ b/com.spoticket.team-stadium/src/test/java/com/spoticket/teamstadium/service/TeamServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -166,7 +165,6 @@ class TeamServiceTest {
     assertEquals(teamId, teamReadResponse.team().teamId());
     assertEquals("Test Team", teamReadResponse.team().name());
     assertEquals(favCnt, teamReadResponse.team().favCnt());
-    assertNull(teamReadResponse.games());
   }
 
   // 팀 목록 조회


### PR DESCRIPTION
# [Feat] 경기장 생성 및 조회 기능 구현

## 개요
경기장 생성 및 조회 기능 구현

## 변경 사항

- TeamRepository 추상화

- 경기장 정보 등록 기능 구현
- 경기장 단일 조회 기능 구현
- 경기장 목록 조회 기능 구현
- 테스트코드 작성

## 스크린샷 (선택사항)

## 특이 사항

resolved: #10 