### PR TITLE
[Feat] 경기 검색 구현

### DIFF
--- a/com.spoticket.games/.gitignore
+++ b/com.spoticket.games/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/java/com/spoticket/game/temp/
+application-dev.yml

--- a/com.spoticket.games/build.gradle
+++ b/com.spoticket.games/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+//    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     compileOnly 'org.projectlombok:lombok'

--- a/com.spoticket.games/src/main/java/com/spoticket/game/application/service/GameCommandService.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/application/service/GameCommandService.java
@@ -3,7 +3,7 @@ package com.spoticket.game.application.service;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.spoticket.game.domain.model.Game;
-import com.spoticket.game.domain.repository.GameRepository;
+import com.spoticket.game.domain.repository.GameJpaRepository;
 import com.spoticket.game.dto.request.CreateGameRequest;
 import com.spoticket.game.dto.request.UpdateGameRequest;
 import com.spoticket.game.dto.response.GameResponse;
@@ -18,18 +18,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class GameCommandService {
 
-  private final GameRepository gameRepository;
+  private final GameJpaRepository gameJpaRepository;
 
   public GameResponse createGame(CreateGameRequest request) {
     Game game = Game.of(
         request.getTitle(), request.getStartTime(), request.getSport(), request.getLeague(),
         request.getStadiumId(), request.getHomeTeamId(), request.getAwayTeamId()
     );
-    return GameResponse.from(gameRepository.save(game));
+    return GameResponse.from(gameJpaRepository.save(game));
   }
 
   public GameResponse updateGame(UUID gameId, UpdateGameRequest request) {
-    Game game = gameRepository.findById(gameId)
+    Game game = gameJpaRepository.findById(gameId)
         .orElseThrow(() -> new CustomException(NOT_FOUND));
     game.update(
         request.getTitle(),
@@ -44,7 +44,7 @@ public class GameCommandService {
   }
 
   public void deleteGame(UUID gameId) {
-    Game game = gameRepository.findById(gameId)
+    Game game = gameJpaRepository.findById(gameId)
         .orElseThrow(() -> new CustomException(NOT_FOUND));
     game.delete();
   }

--- a/com.spoticket.games/src/main/java/com/spoticket/game/application/service/GameQueryService.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/application/service/GameQueryService.java
@@ -3,7 +3,9 @@ package com.spoticket.game.application.service;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.spoticket.game.domain.model.Game;
-import com.spoticket.game.domain.repository.GameRepository;
+import com.spoticket.game.domain.repository.GameJpaRepository;
+import com.spoticket.game.domain.repository.GameQueryRepository;
+import com.spoticket.game.dto.request.SearchCondition;
 import com.spoticket.game.dto.response.GameResponse;
 import com.spoticket.game.dto.response.GenericPagedModel;
 import com.spoticket.game.global.exception.CustomException;
@@ -19,18 +21,23 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class GameQueryService {
 
-  private final GameRepository gameRepository;
+  private final GameJpaRepository gameJpaRepository;
+  private final GameQueryRepository gameQueryRepository;
 
   public GameResponse getGame(UUID gameId) {
-    Game game = gameRepository.findByGameIdAndIsDeleteFalse(gameId)
+    Game game = gameJpaRepository.findByGameIdAndIsDeleteFalse(gameId)
         .orElseThrow(() -> new CustomException(NOT_FOUND));
     return GameResponse.from(game);
   }
 
   public GenericPagedModel<GameResponse> getGamesByStadiumId(UUID stadiumId, Pageable pageable) {
-    Page<GameResponse> page = gameRepository.findAllByStadiumIdAndIsDeleteFalse(stadiumId,
+    Page<GameResponse> page = gameJpaRepository.findAllByStadiumIdAndIsDeleteFalse(stadiumId,
         pageable);
     return GenericPagedModel.of(page);
+  }
+
+  public GenericPagedModel<GameResponse> getGames(SearchCondition condition) {
+    return GenericPagedModel.of(gameQueryRepository.getGames(condition));
   }
 
 }

--- a/com.spoticket.games/src/main/java/com/spoticket/game/application/service/GameQueryService.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/application/service/GameQueryService.java
@@ -11,8 +11,6 @@ import com.spoticket.game.dto.response.GenericPagedModel;
 import com.spoticket.game.global.exception.CustomException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,15 +23,9 @@ public class GameQueryService {
   private final GameQueryRepository gameQueryRepository;
 
   public GameResponse getGame(UUID gameId) {
-    Game game = gameJpaRepository.findByGameIdAndIsDeleteFalse(gameId)
+    Game game = gameJpaRepository.findByGameIdAndIsDeletedFalse(gameId)
         .orElseThrow(() -> new CustomException(NOT_FOUND));
     return GameResponse.from(game);
-  }
-
-  public GenericPagedModel<GameResponse> getGamesByStadiumId(UUID stadiumId, Pageable pageable) {
-    Page<GameResponse> page = gameJpaRepository.findAllByStadiumIdAndIsDeleteFalse(stadiumId,
-        pageable);
-    return GenericPagedModel.of(page);
   }
 
   public GenericPagedModel<GameResponse> getGames(SearchCondition condition) {

--- a/com.spoticket.games/src/main/java/com/spoticket/game/domain/repository/GameJpaRepository.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/domain/repository/GameJpaRepository.java
@@ -1,17 +1,12 @@
 package com.spoticket.game.domain.repository;
 
 import com.spoticket.game.domain.model.Game;
-import com.spoticket.game.dto.response.GameResponse;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GameJpaRepository extends JpaRepository<Game, UUID> {
 
-  Page<GameResponse> findAllByStadiumIdAndIsDeleteFalse(UUID stadiumId, Pageable pageable);
-
-  Optional<Game> findByGameIdAndIsDeleteFalse(UUID gameId);
+  Optional<Game> findByGameIdAndIsDeletedFalse(UUID gameId);
 
 }

--- a/com.spoticket.games/src/main/java/com/spoticket/game/domain/repository/GameJpaRepository.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/domain/repository/GameJpaRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface GameRepository extends JpaRepository<Game, UUID> {
+public interface GameJpaRepository extends JpaRepository<Game, UUID> {
 
   Page<GameResponse> findAllByStadiumIdAndIsDeleteFalse(UUID stadiumId, Pageable pageable);
 

--- a/com.spoticket.games/src/main/java/com/spoticket/game/domain/repository/GameQueryRepository.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/domain/repository/GameQueryRepository.java
@@ -1,0 +1,92 @@
+package com.spoticket.game.domain.repository;
+
+import static com.spoticket.game.domain.model.QGame.game;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.spoticket.game.domain.model.Game;
+import com.spoticket.game.domain.model.Sport;
+import com.spoticket.game.domain.repository.support.Querydsl4RepositorySupport;
+import com.spoticket.game.dto.request.SearchCondition;
+import com.spoticket.game.dto.response.GameResponse;
+import com.spoticket.game.dto.response.QGameResponse;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class GameQueryRepository extends Querydsl4RepositorySupport {
+
+  public GameQueryRepository() {
+    super(Game.class);
+  }
+
+  public Page<GameResponse> getGames(SearchCondition condition) {
+    return applyPagination(condition.getPageable(), contentQuery -> contentQuery
+            .select(new QGameResponse(game.gameId, game.title, game.startTime, game.sport, game.league,
+                game.stadiumId, game.homeTeamId, game.awayTeamId))
+            .from(game)
+            .where(createSearchBooleanBuilder(condition)),
+        countQuery -> countQuery
+            .select(game.count())
+            .from(game)
+            .where(createSearchBooleanBuilder(condition))
+    );
+  }
+
+  private BooleanBuilder createSearchBooleanBuilder(SearchCondition condition) {
+    return titleContains(condition.getTitle())
+        .and(sportEq(condition.getSport()))
+        .and(leagueEq(condition.getLeague()))
+        .and(stadiumIdEq(condition.getStadiumId()))
+        .and(teamIdEq(condition.getTeamId()))
+        .and(startTimeBetween(condition.getStartDateTime(), condition.getEndDateTime()));
+  }
+
+  private BooleanBuilder titleContains(String titleCond) {
+    return nullSafeBuilder(() -> game.title.containsIgnoreCase(titleCond));
+  }
+
+  private BooleanBuilder sportEq(Sport sportCond) {
+    return nullSafeBuilder(() -> game.sport.eq(sportCond));
+  }
+
+  private BooleanBuilder leagueEq(String leagueCond) {
+    return nullSafeBuilder(() -> game.league.eq(leagueCond));
+  }
+
+  private BooleanBuilder stadiumIdEq(UUID stadiumIdCond) {
+    return nullSafeBuilder(() -> game.stadiumId.eq(stadiumIdCond));
+  }
+
+  private BooleanBuilder teamIdEq(UUID teamIdCond) {
+    return nullSafeBuilder(() ->
+        game.homeTeamId.eq(teamIdCond).or(game.awayTeamId.eq(teamIdCond))
+    );
+  }
+
+  private BooleanBuilder startTimeBetween(LocalDateTime start, LocalDateTime end) {
+    return nullSafeBuilder(() -> {
+      if (start != null && end != null) {
+        return game.startTime.between(start, end);
+      } else if (start != null) {
+        return game.startTime.goe(start);
+      } else if (end != null) {
+        return game.startTime.loe(end);
+      } else {
+        return null;
+      }
+    });
+  }
+
+  private BooleanBuilder nullSafeBuilder(Supplier<BooleanExpression> f) {
+    try {
+      return new BooleanBuilder(f.get());
+    } catch (Exception e) {
+      return new BooleanBuilder();
+    }
+  }
+
+}

--- a/com.spoticket.games/src/main/java/com/spoticket/game/domain/repository/support/Querydsl4RepositorySupport.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/domain/repository/support/Querydsl4RepositorySupport.java
@@ -1,0 +1,103 @@
+package com.spoticket.game.domain.repository.support;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.function.Function;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
+import org.springframework.data.jpa.repository.support.Querydsl;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
+
+/**
+ * Querydsl 4.x 버전에 맞춘 Querydsl 지원 라이브러리
+ *
+ * @author Jason Lee
+ * @see org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+ */
+@Repository
+public abstract class Querydsl4RepositorySupport {
+
+  private final Class domainClass;
+  private Querydsl querydsl;
+  private EntityManager entityManager;
+  private JPAQueryFactory queryFactory;
+
+  public Querydsl4RepositorySupport(Class<?> domainClass) {
+    Assert.notNull(domainClass, "Domain class must not be null!");
+    this.domainClass = domainClass;
+  }
+
+  @Autowired
+  public void setEntityManager(EntityManager entityManager) {
+    Assert.notNull(entityManager, "EntityManager must not be null!");
+    JpaEntityInformation entityInformation =
+        JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager);
+    SimpleEntityPathResolver resolver = SimpleEntityPathResolver.INSTANCE;
+    EntityPath path = resolver.createPath(entityInformation.getJavaType());
+    this.entityManager = entityManager;
+    this.querydsl = new Querydsl(entityManager, new
+        PathBuilder<>(path.getType(), path.getMetadata()));
+    this.queryFactory = new JPAQueryFactory(entityManager);
+  }
+
+  @PostConstruct
+  public void validate() {
+    Assert.notNull(entityManager, "EntityManager must not be null!");
+    Assert.notNull(querydsl, "Querydsl must not be null!");
+    Assert.notNull(queryFactory, "QueryFactory must not be null!");
+  }
+
+  protected JPAQueryFactory getQueryFactory() {
+    return queryFactory;
+  }
+
+  protected Querydsl getQuerydsl() {
+    return querydsl;
+  }
+
+  protected EntityManager getEntityManager() {
+    return entityManager;
+  }
+
+  protected <T> JPAQuery<T> select(Expression<T> expr) {
+    return getQueryFactory().select(expr);
+  }
+
+  protected <T> JPAQuery<T> selectFrom(EntityPath<T> from) {
+    return getQueryFactory().selectFrom(from);
+  }
+
+  protected <T> Page<T> applyPagination(Pageable pageable,
+      Function<JPAQueryFactory, JPAQuery> contentQuery) {
+    JPAQuery jpaQuery = contentQuery.apply(getQueryFactory());
+    List<T> content = getQuerydsl().applyPagination(pageable,
+        jpaQuery).fetch();
+    return PageableExecutionUtils.getPage(content, pageable,
+        jpaQuery::fetchCount);
+  }
+
+  protected <T> Page<T> applyPagination(Pageable pageable,
+      Function<JPAQueryFactory, JPAQuery> contentQuery, Function<JPAQueryFactory,
+          JPAQuery> countQuery) {
+    JPAQuery jpaContentQuery = contentQuery.apply(getQueryFactory());
+    List<T> content = getQuerydsl().applyPagination(pageable,
+        jpaContentQuery).fetch();
+
+    JPAQuery countResult = countQuery.apply(getQueryFactory());
+    return PageableExecutionUtils.getPage(content, pageable,
+        countResult::fetchCount);
+  }
+
+}

--- a/com.spoticket.games/src/main/java/com/spoticket/game/dto/request/SearchCondition.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/dto/request/SearchCondition.java
@@ -1,0 +1,23 @@
+package com.spoticket.game.dto.request;
+
+import com.spoticket.game.domain.model.Sport;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.domain.Pageable;
+
+@Getter
+@Setter
+public class SearchCondition {
+
+  private String title;
+  private Sport sport;
+  private String league;
+  private UUID stadiumId;
+  private UUID teamId;
+  private LocalDateTime startDateTime;
+  private LocalDateTime endDateTime;
+  private Pageable pageable;
+
+}

--- a/com.spoticket.games/src/main/java/com/spoticket/game/dto/response/GameResponse.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/dto/response/GameResponse.java
@@ -1,5 +1,6 @@
 package com.spoticket.game.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import com.spoticket.game.domain.model.Game;
 import com.spoticket.game.domain.model.Sport;
 import java.time.LocalDateTime;
@@ -31,6 +32,20 @@ public class GameResponse {
         .homeTeamId(game.getHomeTeamId())
         .awayTeamId(game.getAwayTeamId())
         .build();
+  }
+
+  @QueryProjection
+  public GameResponse(UUID gameId, String title, LocalDateTime startTime, Sport sport,
+      String league,
+      UUID stadiumId, UUID homeTeamId, UUID awayTeamId) {
+    this.gameId = gameId;
+    this.title = title;
+    this.startTime = startTime;
+    this.sport = sport;
+    this.league = league;
+    this.stadiumId = stadiumId;
+    this.homeTeamId = homeTeamId;
+    this.awayTeamId = awayTeamId;
   }
 
 }

--- a/com.spoticket.games/src/main/java/com/spoticket/game/infrastructure/config/QuerydslConfig.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/infrastructure/config/QuerydslConfig.java
@@ -1,0 +1,16 @@
+package com.spoticket.game.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+  @Bean
+  JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+    return new JPAQueryFactory(entityManager);
+  }
+  
+}

--- a/com.spoticket.games/src/main/java/com/spoticket/game/presentation/controller/GameController.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/presentation/controller/GameController.java
@@ -10,6 +10,7 @@ import static com.spoticket.game.global.util.ResponseUtils.ok;
 import com.spoticket.game.application.service.GameCommandService;
 import com.spoticket.game.application.service.GameQueryService;
 import com.spoticket.game.dto.request.CreateGameRequest;
+import com.spoticket.game.dto.request.SearchCondition;
 import com.spoticket.game.dto.request.UpdateGameRequest;
 import com.spoticket.game.dto.response.GameResponse;
 import com.spoticket.game.global.exception.CustomException;
@@ -36,6 +37,26 @@ public class GameController {
   private final GameCommandService gameCommandService;
   private final GameQueryService gameQueryService;
 
+  // Query
+  @GetMapping("/{gameId}")
+  public DataResponse<GameResponse> getGame(@PathVariable UUID gameId) {
+    return ok(gameQueryService.getGame(gameId));
+  }
+
+  /*@GetMapping
+  public DataResponse<PagedModel<GameResponse>> getGamesByStadiumId(UUID stadiumId,
+      Pageable pageable) {
+    return ok(gameQueryService.getGamesByStadiumId(stadiumId, pageable));
+  }*/
+
+  @GetMapping
+  public DataResponse<PagedModel<GameResponse>> getGames(SearchCondition condition,
+      Pageable pageable) {
+    condition.setPageable(pageable);
+    return ok(gameQueryService.getGames(condition));
+  }
+
+  // Command
   @PostMapping
   public DataResponse<GameResponse> createGame(
       @Valid @RequestBody CreateGameRequest request,
@@ -43,17 +64,6 @@ public class GameController {
   ) throws CustomException {
     validateAndThrowIfInvalid(result);
     return created(gameCommandService.createGame(request));
-  }
-
-  @GetMapping("/{gameId}")
-  public DataResponse<GameResponse> getGame(@PathVariable UUID gameId) {
-    return ok(gameQueryService.getGame(gameId));
-  }
-
-  @GetMapping
-  public DataResponse<PagedModel<GameResponse>> getGamesByStadiumId(UUID stadiumId,
-      Pageable pageable) {
-    return ok(gameQueryService.getGamesByStadiumId(stadiumId, pageable));
   }
 
   @PatchMapping("/{gameId}")

--- a/com.spoticket.games/src/main/java/com/spoticket/game/presentation/controller/GameController.java
+++ b/com.spoticket.games/src/main/java/com/spoticket/game/presentation/controller/GameController.java
@@ -43,12 +43,6 @@ public class GameController {
     return ok(gameQueryService.getGame(gameId));
   }
 
-  /*@GetMapping
-  public DataResponse<PagedModel<GameResponse>> getGamesByStadiumId(UUID stadiumId,
-      Pageable pageable) {
-    return ok(gameQueryService.getGamesByStadiumId(stadiumId, pageable));
-  }*/
-
   @GetMapping
   public DataResponse<PagedModel<GameResponse>> getGames(SearchCondition condition,
       Pageable pageable) {

--- a/com.spoticket.games/src/test/java/com/spoticket/game/GameApplicationTests.java
+++ b/com.spoticket.games/src/test/java/com/spoticket/game/GameApplicationTests.java
@@ -6,9 +6,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class GameApplicationTests {
 
-    @Test
-    void contextLoads() {
+  @Test
+  void contextLoads() {
 
-    }
+  }
 
 }

--- a/com.spoticket.games/src/test/java/com/spoticket/game/GameDataInitializationTest.java
+++ b/com.spoticket.games/src/test/java/com/spoticket/game/GameDataInitializationTest.java
@@ -1,0 +1,43 @@
+package com.spoticket.game;
+
+import static com.spoticket.game.domain.model.Sport.BASKETBALL;
+import static com.spoticket.game.domain.model.Sport.SOCCER;
+import static java.time.LocalDateTime.now;
+import static java.util.UUID.randomUUID;
+
+import com.spoticket.game.domain.model.Game;
+import com.spoticket.game.domain.model.Sport;
+import com.spoticket.game.domain.repository.GameJpaRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@Commit
+class GameDataInitializationTest {
+
+  @Autowired
+  private GameJpaRepository gameJpaRepository;
+
+  @Test
+  void init() {
+    UUID stadiumId = randomUUID();
+
+    for (int i = 0; i < 100; i++) {
+      String title = "Game " + i;
+      LocalDateTime startTime = now().plusDays(i);
+      Sport sport = (i % 2 == 0) ? SOCCER : BASKETBALL;
+      String league = (i % 2 == 0) ? "Premier League" : "NBA";
+      UUID homeTeamId = randomUUID();
+      UUID awayTeamId = randomUUID();
+      Game game = Game.of(title, startTime, sport, league, stadiumId, homeTeamId, awayTeamId);
+      gameJpaRepository.save(game);
+    }
+  }
+
+}

--- a/com.spoticket.games/src/test/java/com/spoticket/game/GameDataInitializationTest.java
+++ b/com.spoticket.games/src/test/java/com/spoticket/game/GameDataInitializationTest.java
@@ -27,7 +27,6 @@ class GameDataInitializationTest {
   @Test
   void init() {
     UUID stadiumId = randomUUID();
-
     for (int i = 0; i < 100; i++) {
       String title = "Game " + i;
       LocalDateTime startTime = now().plusDays(i);

--- a/com.spoticket.games/src/test/java/com/spoticket/game/application/service/GameQueryServiceTest.java
+++ b/com.spoticket.games/src/test/java/com/spoticket/game/application/service/GameQueryServiceTest.java
@@ -8,7 +8,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import com.spoticket.game.domain.model.Game;
 import com.spoticket.game.domain.model.Sport;
-import com.spoticket.game.domain.repository.GameRepository;
+import com.spoticket.game.domain.repository.GameJpaRepository;
 import com.spoticket.game.dto.response.GameResponse;
 import com.spoticket.game.global.exception.CustomException;
 import java.time.LocalDateTime;
@@ -23,7 +23,7 @@ import org.mockito.MockitoAnnotations;
 class GameQueryServiceTest {
 
   @Mock
-  private GameRepository gameRepository;
+  private GameJpaRepository gameJpaRepository;
 
   @InjectMocks
   private GameQueryService gameQueryService;
@@ -41,7 +41,7 @@ class GameQueryServiceTest {
   @Test
   void getGame_success() {
     // given
-    when(gameRepository.findByGameIdAndIsDeleteFalse(any(UUID.class))).thenReturn(
+    when(gameJpaRepository.findByGameIdAndIsDeleteFalse(any(UUID.class))).thenReturn(
         Optional.of(game));
 
     // when
@@ -75,7 +75,8 @@ class GameQueryServiceTest {
   @Test
   void getGame_notFound() {
     // given
-    when(gameRepository.findByGameIdAndIsDeleteFalse(any(UUID.class))).thenReturn(Optional.empty());
+    when(gameJpaRepository.findByGameIdAndIsDeleteFalse(any(UUID.class))).thenReturn(
+        Optional.empty());
 
     // when & then
     assertThatThrownBy(() -> gameQueryService.getGame(UUID.randomUUID()))

--- a/com.spoticket.games/src/test/java/com/spoticket/game/application/service/GameQueryServiceTest.java
+++ b/com.spoticket.games/src/test/java/com/spoticket/game/application/service/GameQueryServiceTest.java
@@ -41,7 +41,7 @@ class GameQueryServiceTest {
   @Test
   void getGame_success() {
     // given
-    when(gameJpaRepository.findByGameIdAndIsDeleteFalse(any(UUID.class))).thenReturn(
+    when(gameJpaRepository.findByGameIdAndIsDeletedFalse(any(UUID.class))).thenReturn(
         Optional.of(game));
 
     // when
@@ -75,7 +75,7 @@ class GameQueryServiceTest {
   @Test
   void getGame_notFound() {
     // given
-    when(gameJpaRepository.findByGameIdAndIsDeleteFalse(any(UUID.class))).thenReturn(
+    when(gameJpaRepository.findByGameIdAndIsDeletedFalse(any(UUID.class))).thenReturn(
         Optional.empty());
 
     // when & then

--- a/com.spoticket.user/src/main/java/com/spoticket/user/global/entity/BaseEntity.java
+++ b/com.spoticket.user/src/main/java/com/spoticket/user/global/entity/BaseEntity.java
@@ -2,6 +2,8 @@ package com.spoticket.user.global.entity;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -9,36 +11,33 @@ import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
-    private boolean isDelete = false;
+  private boolean isDeleted = false;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
+  @CreatedDate
+  private LocalDateTime createdAt;
 
-    @CreatedBy
-    private UUID createdBy;
+  @CreatedBy
+  private UUID createdBy;
 
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
 
-    @LastModifiedBy
-    private UUID updatedBy;
+  @LastModifiedBy
+  private UUID updatedBy;
 
-    private LocalDateTime deletedAt;
+  private LocalDateTime deletedAt;
 
-    private UUID deletedBy;
+  private UUID deletedBy;
 
-    public void delete(UUID deletedBy) {
-        this.isDelete = true;
-        this.deletedAt = LocalDateTime.now();
-        this.deletedBy = deletedBy;
-    }
+  public void delete(UUID deletedBy) {
+    this.isDeleted = true;
+    this.deletedAt = LocalDateTime.now();
+    this.deletedBy = deletedBy;
+  }
 
 }


### PR DESCRIPTION
# PR 제목
[Feat] 경기 검색

## 개요
<!-- PR이 해결하려는 문제에 대한 간단한 설명 -->
경기를 검색하는 기능을 구현합니다.

## 변경 사항
<!-- 구현한 기능 또는 수정한 부분 목록 -->
아래 요소들을 조합해 조건에 맞는 경기 목록을 조회
- 경기 제목
- 종목
- 리그
- 경기장
- 팀
- 경기 시작시간이 startDateTime과 endDateTime 사이인 경기목록

## 스크린샷 (선택사항)
<!-- UI 변경사항을 보여주는 스크린샷 -->

## 특이 사항
<!-- 리뷰어가 알아야 할 사항이나 특별히 주의해야 할 점 -->
- resolved: #3 