### PR TITLE
[FEAT]결제 관련 서비스 로직 추가 및 수정

### DIFF
--- a/com.spoticket.payment/build.gradle
+++ b/com.spoticket.payment/build.gradle
@@ -28,17 +28,22 @@ ext {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 }
 
 dependencyManagement {

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/application/payment/dto/PaymentCreateReq.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/application/payment/dto/PaymentCreateReq.java
@@ -1,0 +1,19 @@
+package com.spoticket.payment.application.payment.dto;
+
+import com.spoticket.payment.domain.order.model.OrderItem;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class PaymentCreateReq {
+
+    private UUID orderId;
+    private long amount;
+    private String itemName;
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/application/payment/dto/PaymentRes.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/application/payment/dto/PaymentRes.java
@@ -1,0 +1,17 @@
+package com.spoticket.payment.application.payment.dto;
+
+import com.spoticket.payment.domain.payment.model.PaymentStatus;
+import com.spoticket.payment.domain.payment.model.Payments;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PaymentRes (UUID paymentId, UUID orderId, long amount, PaymentStatus status, LocalDateTime created_at ){
+
+    public static PaymentRes from(Payments payments) {
+        return new PaymentRes(payments.getPaymentId(),
+            payments.getOrderId(),
+            payments.getAmount(),
+            payments.getStatus(),
+            payments.getCreatedAt());
+    }
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/application/payment/service/PaymentService.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/application/payment/service/PaymentService.java
@@ -1,0 +1,149 @@
+package com.spoticket.payment.application.payment.service;
+
+
+
+
+import com.spoticket.payment.application.payment.dto.PaymentRes;
+import com.spoticket.payment.domain.payment.exception.PaymentErrorCode;
+import com.spoticket.payment.domain.payment.exception.PaymentException;
+import com.spoticket.payment.domain.payment.model.PaymentHistories;
+import com.spoticket.payment.domain.payment.model.PaymentStatus;
+import com.spoticket.payment.domain.payment.model.Payments;
+import com.spoticket.payment.domain.payment.port.TossPaymentPort;
+import com.spoticket.payment.domain.payment.repository.PaymentHistoryRepository;
+import com.spoticket.payment.domain.payment.repository.PaymentRepository;
+import com.spoticket.payment.domain.payment.service.PaymentDomainService;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentReq;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentRes;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentHistoryRepository paymentHistoryRepository;
+    private final TossPaymentPort paymentPort;
+    private final PaymentDomainService paymentDomainService;
+
+
+
+    @Transactional
+    public void createOrReusePayment(UUID orderId, long amount) {
+        if (isReusablePayment(orderId)) {
+            createPayment(orderId, amount);
+        }
+    }
+    public void createPayment(UUID orderId, long amount) {
+        log.info("결제 생성 시작 - orderId: {}, amount: {}, timestamp: {}",
+            orderId, amount, LocalDateTime.now());
+
+        Payments payment = Payments.createPayments(
+            orderId, amount
+        );
+        Payments savedPayment = paymentRepository.save(payment);
+        log.info("결제 생성 성공 - paymentId: {}, orderId: {}, amount: {}, createdAt: {}",
+            savedPayment.getPaymentId(),
+            savedPayment.getOrderId(),
+            savedPayment.getAmount(),
+            savedPayment.getCreatedAt());
+    }
+
+    private boolean isReusablePayment(UUID orderId) {
+        Optional<Payments> existingPayment = paymentRepository.findByOrderId(orderId);
+        if (existingPayment.isEmpty()) {
+            return true;
+        }
+        Payments payment = existingPayment.get();
+        if (payment.getStatus() == PaymentStatus.PENDING) {
+            log.info("기존 PENDING 상태 결제 재사용 - paymentId: {}, orderId: {}",
+                payment.getPaymentId(), orderId);
+            return false;
+        }
+        log.warn("이미 처리된 주문의 결제 요청 - orderId: {}, status: {}",
+            orderId, payment.getStatus());
+        throw new PaymentException(PaymentErrorCode.PAYMENT_ALREADY_PROCESSED);
+    }
+
+
+    @Transactional
+    public TossPaymentRes confirmPayment(TossPaymentReq paymentReq) {
+        Payments payment = paymentRepository.findByOrderId(paymentReq.orderId())
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        TossPaymentRes paymentRes = paymentPort.confirmPayment(paymentReq);
+        verifyAmount(paymentReq.amount(), paymentRes.totalAmount());
+        paymentDomainService.updatePaymentStatus(
+            payment,
+            paymentRes.status(),
+            paymentReq.paymentKey()
+        );
+        String cardCompanyName = convertCardCompanyName(paymentRes.card().issuerCode());
+        paymentHistoryRepository.save(
+            PaymentHistories.createPaymentStatusHistory(
+                payment,
+                paymentRes.method(),
+                paymentRes.status(),
+                paymentRes.description(),
+                cardCompanyName,
+                paymentRes.card().installmentPlanMonths()
+            )
+        );
+        log.info("결제 승인 완료 응답 - paymentId: {}, method: {}, status: {}, description: {}, cardCompanyName: {}",
+            payment.getPaymentId(),
+            paymentRes.method(),
+            paymentRes.status(),
+            paymentRes.description(),
+            cardCompanyName
+        );
+        return paymentRes;
+    }
+    public void verifyAmount(long reqAmount, long resAmount ) {
+        if (reqAmount != resAmount) {
+            throw new PaymentException(PaymentErrorCode.AMOUNT_NOT_EQUAL);
+        }
+    }
+    @Transactional
+    public TossPaymentRes cancelPayment(String paymentKey, String cancelReason) {
+        Payments payment = paymentRepository.findByPaymentKey(paymentKey)
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        TossPaymentRes paymentRes = paymentPort.cancelPayment(
+            paymentKey,
+            cancelReason
+        );
+        paymentDomainService.updatedPaymentStatusByCancel(
+            payment,
+            paymentRes.status()
+        );
+
+        String cardCompanyName = convertCardCompanyName(paymentRes.card().issuerCode());
+
+        paymentHistoryRepository.save(
+            PaymentHistories.createPaymentStatusHistory(
+                payment,
+                paymentRes.method(),
+                paymentRes.status(),
+                cancelReason,
+                cardCompanyName,
+                paymentRes.card().installmentPlanMonths())
+        );
+        return paymentRes;
+    }
+
+    private String convertCardCompanyName(String issuerCode) {
+        return paymentPort.getCardCompanyName(issuerCode);
+    }
+
+    public PaymentRes getPayment(UUID paymentId) {
+        return PaymentRes.from(paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND)));
+
+    }
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/exception/PaymentErrorCode.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/exception/PaymentErrorCode.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 
 @Getter
 public enum PaymentErrorCode implements ErrorCode {
-    PAYMENT_NOT_FOUND(404, "결제 정보를 찾을 수 없습니다");
+    PAYMENT_NOT_FOUND(404, "결제 정보를 찾을 수 없습니다"),
+    AMOUNT_NOT_EQUAL(400, "결제 금액이 일치하지 않습니다."),
+    PAYMENT_ALREADY_PROCESSED(400, "이미 처리된 결제입니다, 다시 시도 해주세요" );
 
     private final int code;
     private final String message;

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/CardCompany.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/CardCompany.java
@@ -1,0 +1,51 @@
+package com.spoticket.payment.domain.payment.model;
+
+import java.util.Arrays;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CardCompany {
+   IBK("3K", "기업 BC", "기업비씨", "IBK_BC"),
+   GWANGJU("46", "광주은행", "광주", "GWANGJUBANK"),
+   LOTTE("71", "롯데카드", "롯데", "LOTTE"),
+   KDB("30", "KDB산업은행", "산업", "KDBBANK"),
+   BC("31", "BC카드", "비씨", "BC"),
+   SAMSUNG("51", "삼성카드", "삼성", "SAMSUNG"),
+   SAEMAEUL("38", "새마을금고", "새마을", "SAEMAUL"),
+   SHINHAN("41", "신한카드", "신한", "SHINHAN"),
+   SHINHYEOP("62", "신협", "신협", "SHINHYEOP"),
+   CITI("36", "씨티카드", "씨티", "CITI"),
+   WOORI_BC("33", "우리BC카드(BC 매입)", "우리", "WOORI"),
+   WOORI("W1", "우리카드(우리 매입)", "우리", "WOORI"),
+   POST("37", "우체국예금보험", "우체국", "POST"),
+   SAVING_BANK("39", "저축은행중앙회", "저축", "SAVINGBANK"),
+   JEONBUK("35", "전북은행", "전북", "JEONBUKBANK"),
+   JEJU("42", "제주은행", "제주", "JEJUBANK"),
+   KAKAO("15", "카카오뱅크", "카카오뱅크", "KAKAOBANK"),
+   KBANK("3A", "케이뱅크", "케이뱅크", "KBANK"),
+   TOSS("24", "토스뱅크", "토스뱅크", "TOSSBANK"),
+   HANA("21", "하나카드", "하나", "HANA"),
+   HYUNDAI("61", "현대카드", "현대", "HYUNDAI"),
+   KOOKMIN("11", "KB국민카드", "국민", "KOOKMIN"),
+   NONGHYEOP("91", "NH농협카드", "농협", "NONGHYEOP"),
+   SUHYEOP("34", "Sh수협은행", "수협", "SUHYEOP");
+
+   private final String code;
+   private final String fullName;
+   private final String shortName;
+   private final String englishName;
+
+
+
+   public static String getShortNameByCode(String code) {
+       return Arrays.stream(CardCompany.values())
+               .filter(company -> company.code.equals(code))
+               .map(CardCompany::getShortName)
+               .findFirst()
+               .orElse("알 수 없음");
+   }
+
+
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/PaymentHistories.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/PaymentHistories.java
@@ -11,7 +11,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "P_payment_histories", schema = "payment_service")
 public class PaymentHistories {
@@ -26,13 +34,19 @@ public class PaymentHistories {
     @Column(nullable = false)
     private long amount;
 
+    @Column(name = "issuer_code", length = 10)
+    private String issuerCode;
+
+    @Column(name = "installment_months")
+    private int installmentMonths;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 20, nullable = false)
     private PaymentStatus status;
 
-    @Enumerated(EnumType.STRING)
+
     @Column(name = "payment_method", length = 20, nullable = false)
-    private PaymentMethod paymentMethod;
+    private String paymentMethod;
 
     @Column(name = "description")
     private String description;
@@ -48,4 +62,22 @@ public class PaymentHistories {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public static PaymentHistories createPaymentStatusHistory(Payments payment, String method ,String tossStatus, String description , String issuerCode,         // 새로운 파라미터
+        int installmentMonths  ) {
+        return PaymentHistories.builder()
+            .paymentId(payment.getPaymentId())
+            .status(PaymentStatus.fromTossStatus(tossStatus))
+            .issuerCode(issuerCode)
+            .installmentMonths(installmentMonths)
+            .amount(payment.getAmount())
+            .paymentMethod(method)
+            .description(description)
+            .createdBy(payment.getOrderId().toString())
+            .createdAt(LocalDateTime.now())
+            .updatedBy(payment.getOrderId().toString())
+            .updatedAt(LocalDateTime.now())
+            .build();
+    }
+
 }

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/PaymentMethod.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/PaymentMethod.java
@@ -2,7 +2,8 @@ package com.spoticket.payment.domain.payment.model;
 
 public enum PaymentMethod {
     CARD("카드"),
-    TRANSFER("계좌이체");
+    TRANSFER("계좌이체"),
+    EASY_PAY("간편결제");
 
     PaymentMethod(String description) {
     }

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/PaymentStatus.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/PaymentStatus.java
@@ -5,12 +5,22 @@ import lombok.Getter;
 @Getter
 public enum PaymentStatus {
     PENDING("결제 대기"),
-    CANCEL("결제 취소"),
-    COMPLETED("결제 완료");
+    COMPLETED("결제 완료"),
+    CANCELLED("결제 취소"),
+    DONE("결제 승인 완료");
 
     private final String description;
 
     PaymentStatus(String description) {
         this.description = description;
     }
+
+
+public static PaymentStatus fromTossStatus(String tossStatus) {
+    return switch (tossStatus) {
+        case "DONE" -> COMPLETED;
+        case "CANCELED" -> CANCELLED;
+        default -> throw new IllegalArgumentException("알 수 없는 상태 값 : " + tossStatus);
+    };
+}
 }

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/Payments.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/model/Payments.java
@@ -31,6 +31,9 @@ public class Payments {
     @Column(name = "status", length = 20, nullable = false)
     private PaymentStatus status;
 
+    @Column(name = "payment_key", length = 201)
+    private String paymentKey;
+
     @Column(name = "created_by", length = 50, nullable = false)
     private String createdBy;
 
@@ -42,5 +45,27 @@ public class Payments {
 
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public static Payments createPayments(UUID orderId, long amount) {
+        return Payments.builder()
+            .orderId(orderId)
+            .amount(amount)
+            .status(PaymentStatus.PENDING)
+            .createdBy(orderId.toString())
+            .createdAt(LocalDateTime.now())
+            .updatedBy(orderId.toString())
+            .updatedAt(LocalDateTime.now())
+            .build();
+    }
+    public void updateToComplete(String paymentKey) {
+        this.paymentKey = paymentKey;
+        this.status = PaymentStatus.COMPLETED;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateToCancel() {
+        this.status = PaymentStatus.CANCELLED;
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/port/TossPaymentPort.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/port/TossPaymentPort.java
@@ -1,0 +1,12 @@
+package com.spoticket.payment.domain.payment.port;
+
+import com.spoticket.payment.domain.payment.model.CardCompany;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentReq;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentRes;
+
+public interface TossPaymentPort {
+    TossPaymentRes confirmPayment(TossPaymentReq paymentReq);
+    TossPaymentRes cancelPayment(String paymentKey, String cancelReason);
+
+    String getCardCompanyName(String issuerCode);
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/repository/PaymentHistoryRepository.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/repository/PaymentHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.spoticket.payment.domain.payment.repository;
+
+import com.spoticket.payment.domain.payment.model.PaymentHistories;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentHistoryRepository extends JpaRepository<PaymentHistories, UUID> {
+
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/repository/PaymentRepository.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,12 @@
+package com.spoticket.payment.domain.payment.repository;
+
+import com.spoticket.payment.domain.payment.model.Payments;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payments, UUID> {
+    Optional<Payments> findByOrderId(UUID orderId);
+    Optional<Payments> findByPaymentKey(String paymentKey);
+
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/service/PaymentDomainService.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/domain/payment/service/PaymentDomainService.java
@@ -1,0 +1,28 @@
+package com.spoticket.payment.domain.payment.service;
+
+import com.spoticket.payment.domain.payment.model.PaymentStatus;
+import com.spoticket.payment.domain.payment.model.Payments;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentDomainService {
+
+    public void updatePaymentStatus(Payments payment, String tossStatus, String paymentKey) {
+        PaymentStatus newStatus = PaymentStatus.fromTossStatus(tossStatus);
+        if (newStatus == PaymentStatus.COMPLETED) {
+            payment.updateToComplete(paymentKey);
+        } else {
+            throw new IllegalStateException("상태 변경 불가");
+        }
+    }
+
+    public void updatedPaymentStatusByCancel(Payments payment, String tossStatus) {
+        PaymentStatus newStatus = PaymentStatus.fromTossStatus(tossStatus);
+
+        if (newStatus == PaymentStatus.CANCELLED) {
+            payment.updateToCancel();
+        }
+    }
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/TossClient.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/TossClient.java
@@ -1,0 +1,69 @@
+package com.spoticket.payment.infrastrucutre.toss;
+
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentReq;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentRes;
+import jakarta.annotation.PostConstruct;
+import jakarta.ws.rs.core.HttpHeaders;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@Getter
+@RequiredArgsConstructor
+public class TossClient {
+
+    @Value("${toss.api.toss_secret}")
+    private String secretKey;
+    private final String tossURL = "https://api.tosspayments.com/v1/payments/confirm";
+    private final String cancelTossURL = "https://api.tosspayments.com/v1/payments/";
+    private RestClient restClient;
+
+    @PostConstruct
+    public void init() {
+        this.restClient = RestClient.builder()
+            .defaultHeader(HttpHeaders.AUTHORIZATION, createAuthHeader())
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
+    }
+
+    private String createAuthHeader() {
+        byte[] encodedBytes = Base64.getEncoder().encode((secretKey + ":").getBytes(
+            StandardCharsets.UTF_8));
+        return "Basic " + new String(encodedBytes);
+    }
+
+    public TossPaymentRes confirmPayment(TossPaymentReq paymentReq) {
+        log.info("Payment confirmation request - orderId: {}", paymentReq.orderId());
+
+        TossPaymentRes response = restClient.post()
+            .uri(tossURL)
+            .body(paymentReq)
+            .retrieve()
+            .body(TossPaymentRes.class);
+
+        log.info("Payment confirmation successful - orderId: {}", paymentReq.orderId());
+        return response;
+    }
+
+    public TossPaymentRes cancelPayment(String paymentKey, String cancelReason) {
+        String authorization = Base64.getEncoder()
+            .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+        return restClient.post()
+            .uri(cancelTossURL + "/{paymentKey}/cancel", paymentKey)
+            .header(HttpHeaders.AUTHORIZATION, "Basic " + authorization)
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(Map.of("cancelReason", cancelReason))
+            .retrieve()
+            .body(TossPaymentRes.class);
+    }
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/adaptor/TossPaymentAdapter.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/adaptor/TossPaymentAdapter.java
@@ -1,0 +1,32 @@
+package com.spoticket.payment.infrastrucutre.toss.adaptor;
+
+import com.spoticket.payment.domain.payment.model.CardCompany;
+import com.spoticket.payment.domain.payment.port.TossPaymentPort;
+import com.spoticket.payment.infrastrucutre.toss.TossClient;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentReq;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TossPaymentAdapter implements TossPaymentPort {
+    private final TossClient tossClient;
+    
+    @Override
+    public TossPaymentRes confirmPayment(TossPaymentReq paymentReq) {
+        return tossClient.confirmPayment(paymentReq);
+    }
+
+    @Override
+    public TossPaymentRes cancelPayment(String paymentKey, String cancelReason) {
+        return tossClient.cancelPayment(paymentKey, cancelReason);
+    }
+
+    @Override
+    public String getCardCompanyName(String issuerCode) {
+        return CardCompany.getShortNameByCode(issuerCode);
+    }
+
+
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/dto/TossCancelPaymentReq.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/dto/TossCancelPaymentReq.java
@@ -1,0 +1,6 @@
+package com.spoticket.payment.infrastrucutre.toss.dto;
+
+public record TossCancelPaymentReq(
+   String paymentKey,
+   String cancelReason
+) {}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/dto/TossPaymentFailureRequest.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/dto/TossPaymentFailureRequest.java
@@ -1,0 +1,11 @@
+package com.spoticket.payment.infrastrucutre.toss.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public record TossPaymentFailureRequest(
+    @JsonIgnore
+    String paymentKey,
+    String orderId,
+    String message,
+    String code
+) {}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/dto/TossPaymentReq.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/dto/TossPaymentReq.java
@@ -1,0 +1,12 @@
+package com.spoticket.payment.infrastrucutre.toss.dto;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record TossPaymentReq(
+    String paymentKey,
+    UUID orderId,
+    Long amount) {
+
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/dto/TossPaymentRes.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/infrastrucutre/toss/dto/TossPaymentRes.java
@@ -1,0 +1,13 @@
+package com.spoticket.payment.infrastrucutre.toss.dto;
+
+import java.time.OffsetDateTime;
+import lombok.Builder;
+
+@Builder
+public record TossPaymentRes(String paymentKey, String orderId, String orderName, String status,
+                             Long totalAmount, OffsetDateTime approvedAt, String method, String description, Card card) {
+
+    public record Card(String issuerCode, int installmentPlanMonths) {
+
+    }
+}

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/presentation/payment/controller/PaymentController.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/presentation/payment/controller/PaymentController.java
@@ -1,17 +1,57 @@
 package com.spoticket.payment.presentation.payment.controller;
 
+import com.spoticket.payment.application.payment.dto.PaymentCreateReq;
+import com.spoticket.payment.application.payment.dto.PaymentRes;
+import com.spoticket.payment.application.payment.service.PaymentService;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossCancelPaymentReq;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentReq;
+import com.spoticket.payment.infrastrucutre.toss.dto.TossPaymentRes;
 import com.spoticket.payment.presentation.common.ApiSuccessResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/payments")
 public class PaymentController {
 
-    @GetMapping("/{paymentId}")
-    public ApiSuccessResponse<Void> getPayment(@PathVariable Long paymentId) {
+    private final PaymentService paymentService;
+
+
+    @PostMapping
+    public ApiSuccessResponse<Void> createPayment(@RequestBody PaymentCreateReq req) {
+        paymentService.createOrReusePayment(req.getOrderId(), req.getAmount());
         return ApiSuccessResponse.success(null);
     }
+
+    @PostMapping("/cancel")
+    public ApiSuccessResponse<TossPaymentRes> cancelPayment(@RequestBody TossCancelPaymentReq req) {
+        TossPaymentRes res = paymentService.cancelPayment(req.paymentKey(), req.cancelReason());
+        return ApiSuccessResponse.success(res);
+    }
+
+    @PostMapping("/confirm")
+    public ApiSuccessResponse<TossPaymentRes> confirmPayment(@RequestBody TossPaymentReq req) {
+        TossPaymentRes res = paymentService.confirmPayment(req);
+        return ApiSuccessResponse.success(res);
+    }
+
+    // 아직 미구현
+//    @PostMapping("/fail")
+//    public ApiSuccessResponse<TossPaymentRes> failPayment(@RequestBody TossPaymentReq req) {
+//        return ApiSuccessResponse.success(null);
+//    }
+
+    @GetMapping("/{paymentId}")
+    public ApiSuccessResponse<PaymentRes> getPayment(@PathVariable UUID paymentId) {
+        PaymentRes res = paymentService.getPayment(paymentId);
+        return ApiSuccessResponse.success(res);
+    }
+
 }

--- a/com.spoticket.payment/src/main/java/com/spoticket/payment/presentation/payment/controller/PaymentViewController.java
+++ b/com.spoticket.payment/src/main/java/com/spoticket/payment/presentation/payment/controller/PaymentViewController.java
@@ -1,0 +1,31 @@
+package com.spoticket.payment.presentation.payment.controller;
+
+import com.spoticket.payment.application.order.service.OrderService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class PaymentViewController {
+
+
+    @GetMapping("/payment")
+    public String paymentPage() {
+        return "payment";
+    }
+
+    @GetMapping("/payment/success")
+    public String successPage() {
+        return "success";
+    }
+
+    @GetMapping("/payment/fail")
+    public String failPage() {
+        return "fail";
+    }
+}

--- a/com.spoticket.payment/src/main/resources/static/css/style.css
+++ b/com.spoticket.payment/src/main/resources/static/css/style.css
@@ -1,0 +1,568 @@
+body {
+  background-color: #e8f3ff;
+}
+.p {
+  padding: 0;
+  margin: 0;
+  font-family: Toss Product Sans, -apple-system, BlinkMacSystemFont, Bazier Square, Noto Sans KR, Segoe UI, Apple SD Gothic Neo, Roboto, Helvetica Neue, Arial, sans-serif, Apple Color Emoji,
+  Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+  color: #4e5968;
+  word-break: keep-all;
+  word-wrap: break-word;
+}
+.wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.title {
+  margin: 0 0 4px;
+  font-size: 24px;
+  font-weight: 600;
+  color: #4e5968;
+}
+.box_section {
+  background-color: white;
+  border-radius: 10px;
+  box-shadow: 0 10px 20px rgb(0 0 0 / 1%), 0 6px 6px rgb(0 0 0 / 6%);
+  padding: 50px 50px 50px 50px;
+  margin-top: 30px;
+  margin-right: auto;
+  margin-left: auto;
+  color: #333d4b;
+  align-items: center;
+  text-align: center;
+  overflow-x: auto; /* Add this property for horizontal scrolling */
+  white-space: nowrap; /* Prevent text wrapping */
+}
+:root {
+  --inverseGrey50: #202027;
+  --inverseGrey100: #2c2c35;
+  --inverseGrey200: #3c3c47;
+  --inverseGrey300: #4d4d59;
+  --inverseGrey400: #62626d;
+  --inverseGrey500: #7e7e87;
+  --inverseGrey600: #9e9ea4;
+  --inverseGrey700: #c3c3c6;
+  --inverseGrey800: #e4e4e5;
+  --inverseGrey900: #fff;
+  --background: #fff;
+  --darkBackground: #17171c;
+  --greyBackground: #f2f4f6;
+  --darkGreyBackground: #101013;
+  --layeredBackground: #fff;
+  --darkLayeredBackground: #202027;
+  --floatBackground: #fff;
+  --darkFloatBackground: #2c2c35;
+  --black: #000;
+  --grey50: #f9fafb;
+  --grey100: #f2f4f6;
+  --grey200: #e5e8eb;
+  --grey300: #d1d6db;
+  --grey400: #b0b8c1;
+  --grey500: #8b95a1;
+  --grey600: #6b7684;
+  --grey700: #4e5968;
+  --grey800: #333d4b;
+  --grey900: #191f28;
+  --greyOpacity50: rgba(0, 23, 51, 0.02);
+  --greyOpacity100: rgba(2, 32, 71, 0.05);
+  --greyOpacity200: rgba(0, 27, 55, 0.1);
+  --greyOpacity300: rgba(0, 29, 58, 0.18);
+  --greyOpacity400: rgba(0, 25, 54, 0.31);
+  --greyOpacity500: rgba(3, 24, 50, 0.46);
+  --greyOpacity600: rgba(0, 19, 43, 0.58);
+  --greyOpacity700: rgba(3, 18, 40, 0.7);
+  --greyOpacity800: rgba(0, 12, 30, 0.8);
+  --greyOpacity900: rgba(2, 9, 19, 0.91);
+  --white: #fff;
+  --blue50: #e8f3ff;
+  --blue100: #c9e2ff;
+  --blue200: #90c2ff;
+  --blue300: #64a8ff;
+  --blue400: #4593fc;
+  --blue500: #3182f6;
+  --blue600: #2272eb;
+  --blue700: #1b64da;
+  --blue800: #1957c2;
+  --blue900: #194aa6;
+}
+
+body,
+html {
+  font-family: Toss Product Sans, Tossface, -apple-system, BlinkMacSystemFont, Bazier Square, Noto Sans KR, Segoe UI, Apple SD Gothic Neo, Roboto, Helvetica Neue, Arial, sans-serif, Apple Color Emoji,
+  Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  word-break: keep-all;
+  word-wrap: break-word;
+}
+
+*,
+:after,
+:before {
+  box-sizing: border-box;
+}
+
+.button {
+  color: #f9fafb;
+  background-color: #3182f6;
+  margin: 30px 15px 0px 15px;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 18px;
+  white-space: nowrap;
+  text-align: center;
+  /* vertical-align: middle; */
+  cursor: pointer;
+  border: 0 solid transparent;
+  user-select: none;
+  transition: background 0.2s ease, color 0.1s ease;
+  text-decoration: none;
+  border-radius: 7px;
+  padding: 11px 16px;
+  width: 250px;
+}
+
+.button2 {
+  color: #000000;
+  background-color: #ffffff;
+  margin: 30px 15px 0px 15px;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 18px;
+  white-space: nowrap;
+  text-align: center;
+  /* vertical-align: middle; */
+  cursor: pointer;
+  border: 1px solid #000000;
+  user-select: none;
+  transition: background 0.2s ease, color 0.1s ease;
+  text-decoration: none;
+  border-radius: 7px;
+  padding: 11px 16px;
+  width: 125px;
+}
+
+.button:hover {
+  color: #fff;
+  background-color: #1b64da;
+}
+
+button:disabled,
+input:disabled {
+  opacity: 80%;
+  cursor: not-allowed;
+}
+
+button,
+input,
+textarea {
+  font-family: Toss Product Sans, -apple-system, BlinkMacSystemFont, Bazier Square, Noto Sans KR, Segoe UI, Apple SD Gothic Neo, Roboto, Helvetica Neue, Arial, sans-serif, Apple Color Emoji,
+  Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+}
+
+.color--grey800 {
+  color: #333d4b;
+  color: var(--grey800);
+}
+
+.color--grey700 {
+  color: #4e5968;
+  color: var(--grey700);
+}
+
+.color--grey600 {
+  color: #6b7684;
+  color: var(--grey600);
+}
+
+.color--grey500 {
+  color: #8b95a1;
+  color: var(--grey500);
+}
+
+.color--blue500 {
+  color: #3182f6;
+  color: var(--blue500);
+}
+
+.color--blue700 {
+  color: #1b64da;
+  color: var(--blue700);
+}
+
+.bg--white {
+  background-color: #fff;
+  background-color: var(--white);
+}
+
+.bg--grey100 {
+  background-color: #f2f4f6;
+  background-color: var(--grey100);
+}
+
+.bg--greyOpacity100 {
+  background-color: rgba(2, 32, 71, 0.05);
+  background-color: var(--greyOpacity100);
+}
+
+.bg--greyOpacity200 {
+  background-color: rgba(0, 27, 55, 0.1);
+  background-color: var(--greyOpacity200);
+}
+
+.bg--blue50 {
+  background-color: #e8f3ff;
+  background-color: var(--blue50);
+}
+
+:root {
+  --padding-base-vertical: 11px;
+  --padding-base-horizontal: 16px;
+  --padding-t-vertical: 4px;
+  --padding-t-horizontal: 8px;
+  --padding-s-vertical: 7px;
+  --padding-s-horizontal: 12px;
+  --padding-l-vertical: 11px;
+  --padding-l-horizontal: 22px;
+  --padding-xl-vertical: 18px;
+  --padding-xl-horizontal: 24px;
+  --padding-container-base: 48px;
+}
+
+.padding--base {
+  padding: 11px 16px;
+  padding: var(--padding-base-vertical) var(--padding-base-horizontal);
+}
+
+.padding--t {
+  padding: 4px 8px;
+  padding: var(--padding-t-vertical) var(--padding-t-horizontal);
+}
+
+.padding--s {
+  padding: 7px 12px;
+  padding: var(--padding-s-vertical) var(--padding-s-horizontal);
+}
+
+.padding--l {
+  padding: 11px 22px;
+  padding: var(--padding-l-vertical) var(--padding-l-horizontal);
+}
+
+.padding--xl {
+  padding: 18px 24px;
+  padding: var(--padding-xl-vertical) var(--padding-xl-horizontal);
+}
+
+.text--left {
+  text-align: left;
+}
+
+.text--right {
+  text-align: right;
+}
+
+.text--center {
+  text-align: center;
+}
+
+.text--justify {
+  text-align: justify;
+}
+
+:root {
+  --line-height-base: 1.6;
+  --line-height-adjust: 1.3;
+  --font-size-h1: 56px;
+  --font-size-h2: 48px;
+  --font-size-h3: 36px;
+  --font-size-h4: 32px;
+  --font-size-h5: 24px;
+  --font-size-h6: 20px;
+  --font-size-h7: 17px;
+  --font-size-p: 15px;
+  --font-size-sm: 13px;
+  --font-size-small: 13px;
+  --font-size-xsmall: 11px;
+  --font-weight-bold: bold;
+  --font-weight-semibold: 600;
+  --font-weight-medium: 500;
+  --font-weight-regular: normal;
+}
+
+.typography {
+  margin: 0;
+  padding: 0;
+}
+
+.typography--h1,
+.typography--h2,
+.typography--h3,
+.typography--h4 {
+  line-height: 1.3;
+  line-height: var(--line-height-adjust);
+}
+
+.typography--h1 {
+  font-size: 56px;
+  font-size: var(--font-size-h1);
+}
+
+.typography--h2 {
+  font-size: 48px;
+  font-size: var(--font-size-h2);
+}
+
+.typography--h3 {
+  font-size: 36px;
+  font-size: var(--font-size-h3);
+}
+
+.typography--h4 {
+  font-size: 32px;
+  font-size: var(--font-size-h4);
+}
+
+.typography--p {
+  line-height: 1.6;
+  line-height: var(--line-height-base);
+  font-size: 15px;
+  font-size: var(--font-size-p);
+}
+
+:root {
+  --checkable-size: 24px;
+  --checkable-input-top: 3px;
+  --checkable-input-left: 5px;
+  --checkable-input-width: 14px;
+  --checkable-input-height: 10px;
+  --checkable-input-svg: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.343 4.574l4.243 4.243 7.07-7.071' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  --checkable-label-text-padding: 8px;
+  --indeterminate-checkable-input-top: 7px;
+  --indeterminate-checkable-input-left: 5px;
+  --indeterminate-checkable-input-width: 14px;
+}
+
+:root .checkable--small {
+  --checkable-size: 20px;
+  --checkable-input-top: 2px;
+  --checkable-input-left: 4px;
+  --checkable-input-width: 12px;
+  --checkable-input-height: 9px;
+  --checkable-input-svg: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.286 3.645l3.536 3.536 5.892-5.893' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  --indeterminate-checkable-input-top: 5px;
+  --indeterminate-checkable-input-left: 4px;
+  --indeterminate-checkable-input-width: 12px;
+}
+
+.checkable {
+  position: relative;
+  display: flex;
+}
+
+.checkable + .checkable {
+  margin-top: 12px;
+}
+
+.checkable--inline {
+  display: inline-block;
+}
+
+.checkable--inline + .checkable--inline {
+  margin-top: 0;
+  margin-left: 18px;
+}
+
+.checkable__label {
+  display: inline-block;
+  max-width: 100%;
+  min-height: 24px;
+  min-height: var(--checkable-size);
+  line-height: 1.6;
+  padding-left: 24px;
+  padding-left: var(--checkable-size);
+  margin-bottom: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  color: #4e5968;
+  color: var(--grey700);
+  cursor: pointer;
+}
+
+.checkable__input {
+  position: absolute;
+  margin: 0 0 0 -24px;
+  margin: 0 0 0 calc(var(--checkable-size) * -1);
+  top: 4px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border: none;
+  cursor: pointer;
+}
+
+.checkable__input:after,
+.checkable__input:before {
+  content: "";
+  position: absolute;
+}
+
+.checkable__input:before {
+  top: -4px;
+  left: 0;
+  width: 24px;
+  width: var(--checkable-size);
+  height: 24px;
+  height: var(--checkable-size);
+  border: 2px solid #d1d6db;
+  border: 2px solid var(--grey300);
+  background-color: #fff;
+  background-color: var(--white);
+  transition: border-color 0.1s ease, background-color 0.1s ease;
+}
+
+.checkable__input:after {
+  opacity: 0;
+  transition: opacity 0.1s ease;
+  top: 3px;
+  top: var(--checkable-input-top);
+  left: 5px;
+  left: var(--checkable-input-left);
+  width: 14px;
+  width: var(--checkable-input-width);
+  height: 10px;
+  height: var(--checkable-input-height);
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.343 4.574l4.243 4.243 7.07-7.071' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-image: var(--checkable-input-svg);
+  background-repeat: no-repeat;
+}
+
+.checkable__input[type="checkbox"]:indeterminate:after {
+  top: 7px;
+  top: var(--indeterminate-checkable-input-top);
+  left: 5px;
+  left: var(--indeterminate-checkable-input-left);
+  width: 14px;
+  width: var(--indeterminate-checkable-input-width);
+  height: 0;
+  border: 1px solid #fff;
+  border: 1px solid var(--white);
+  border-radius: 1px;
+  transform: rotate(0);
+}
+
+.checkable__input:focus {
+  outline: 0;
+}
+
+.checkable__input:focus:before,
+.checkable__input:hover:before {
+  background-color: #e8f3ff;
+  background-color: var(--blue50);
+  border-color: #3182f6;
+  border-color: var(--blue500);
+}
+
+.checkable__input:checked:before,
+.checkable__input[type="checkbox"]:indeterminate:before {
+  border-color: #3182f6;
+  border-color: var(--blue500);
+  background-color: #3182f6;
+  background-color: var(--blue500);
+}
+
+.checkable__input:checked:after,
+.checkable__input[type="checkbox"]:indeterminate:after {
+  opacity: 1;
+}
+
+.checkable__input:disabled:before {
+  background-color: #f2f4f6;
+  background-color: var(--grey100);
+  border-color: rgba(0, 23, 51, 0.02);
+  border-color: var(--greyOpacity50);
+}
+
+.checkable__input:disabled:checked:before,
+.checkable__input:disabled[type="checkbox"]:indeterminate:before {
+  background-color: #e5e8eb;
+  background-color: var(--grey200);
+  border-color: #e5e8eb;
+  border-color: var(--grey200);
+}
+
+.checkable__input[type="checkbox"]:before {
+  border-radius: 6px;
+}
+
+.checkable__input[type="radio"]:before {
+  border-radius: 12px;
+}
+
+.checkable__label-text {
+  display: inline-block;
+  padding-left: 8px;
+  padding-left: var(--checkable-label-text-padding);
+}
+
+.checkable--disabled > .checkable__input {
+  cursor: not-allowed;
+}
+
+.checkable--disabled > .checkable__label {
+  color: #b0b8c1;
+  color: var(--grey400);
+  cursor: not-allowed;
+}
+
+.checkable--read-only {
+  pointer-events: none;
+}
+
+.p-flex {
+  display: flex;
+}
+
+:root {
+  --pGridGutter: 24px;
+}
+
+.p-grid {
+  height: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -24px;
+  margin-right: calc(var(--pGridGutter) * -1);
+}
+
+.p-grid-col {
+  flex-grow: 1;
+  padding-right: 24px;
+  padding-right: var(--pGridGutter);
+}
+
+.p-grid-col1 {
+  flex: 0 0 8.33333%;
+  max-width: 8.33333%;
+}
+
+.p-grid-col2 {
+  flex: 0 0 16.66667%;
+  max-width: 16.66667%;
+}
+
+.p-grid-col3 {
+  flex: 0 0 25%;
+  max-width: 25%;
+}
+
+.p-grid-col4 {
+  flex: 0 0 33.33333%;
+  max-width: 33.33333%;
+}
+
+.p-grid-col5 {
+  flex: 0 0 41.66667%;
+  max-width: 41.66667%;
+}

--- a/com.spoticket.payment/src/main/resources/templates/fail.html
+++ b/com.spoticket.payment/src/main/resources/templates/fail.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+</head>
+
+<body>
+<h2> 결제 실패 </h2>
+<p id="code"></p>
+<p id="message"></p>
+</body>
+</html>
+
+<script>
+  const urlParams = new URLSearchParams(window.location.search);
+
+  const codeElement = document.getElementById("code");
+  const messageElement = document.getElementById("message");
+
+  codeElement.textContent = "에러코드: " + urlParams.get("code");
+  messageElement.textContent = "실패 사유: " + urlParams.get("message");
+</script>

--- a/com.spoticket.payment/src/main/resources/templates/payment.html
+++ b/com.spoticket.payment/src/main/resources/templates/payment.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="https://static.toss.im/icons/png/4x/icon-toss-logo.png" />
+  <link rel="stylesheet" type="text/css" href="/css/style.css" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>토스페이먼츠 샘플 프로젝트</title>
+  <!-- SDK 추가 -->
+  <script src="https://js.tosspayments.com/v2/standard"></script>
+</head>
+
+<body>
+<!-- 주문서 영역 -->
+<div class="wrapper">
+  <div class="box_section" style="padding: 40px 30px 50px 30px; margin-top: 30px; margin-bottom: 50px">
+    <h1>일반 결제</h1>
+    <!-- 결제 UI -->
+
+    <!-- 결제하기 버튼 -->
+    <button class="button" style="margin-top: 30px" onclick="requestPayment()">결제하기</button>
+  </div>
+
+</div>
+<script>
+  const amount = {
+    currency: "KRW",
+    value: 50000,
+  };
+  const orderIds = generateOrderId();
+
+
+  // ------  SDK 초기화 ------
+  // TODO: clientKey는 개발자센터의 API 개별 연동 키 > 결제창 연동에 사용하려할 MID > 클라이언트 키로 바꾸세요.
+  // TODO: server.js 의 secretKey 또한 결제위젯 연동 키가 아닌 API 개별 연동 키의 시크릿 키로 변경해야 합니다.
+  // TODO: 구매자의 고유 아이디를 불러와서 customerKey로 설정하세요. 이메일・전화번호와 같이 유추가 가능한 값은 안전하지 않습니다.
+  // @docs https://docs.tosspayments.com/sdk/v2/js#토스페이먼츠-초기화
+  const clientKey = "test_ck_6bJXmgo28e1pJj0EzE1A8LAnGKWx";
+  const customerKey = generateRandomString();
+  const tossPayments = TossPayments(clientKey);
+  // 회원 결제
+  // @docs https://docs.tosspayments.com/sdk/v2/js#tosspaymentspayment
+  const payment = tossPayments.payment({
+    customerKey,
+  });
+  async function requestPayment() {
+    try {
+      const paymentResponse = await fetch("/api/v1/payments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          orderId: orderIds,
+          amount: Number(50000),
+        })
+      });
+      if (!paymentResponse.ok) {
+        throw new Error("결제 정보 생성 실패");
+      }
+        await payment.requestPayment({
+          method: "CARD", // 카드 및 간편결제
+          amount,
+          orderId: orderIds,
+          orderName: "토스 티셔츠 외 2건",
+          successUrl: window.location.origin + "/payment/success", // 결제 요청이 성공하면 리다이렉트되는 URL
+          failUrl: window.location.origin + "/payment/fail", // 결제 요청이 실패하면 리다이렉트되는 URL
+          customerEmail: "customer123@gmail.com",
+          customerName: "김토스",
+
+          card: {
+            useEscrow: false,
+            flowMode: "DEFAULT",
+            useCardPoint: false,
+            useAppCardOnly: false,
+          },
+        });
+    }
+    catch (error) {
+      console.error("Error:", error);
+      alert("결제 중 오류가 발생했습니다.");
+      try {
+        await fetch("/api/v1/payments/fail", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            orderId: orderIds,
+            message: error.message || "결제 요청 실패",
+            code: error.code || "PAYMENT_REQUEST_FAILED",
+          })
+        });
+      } catch (sendError) {
+        console.error("Failed to send error to server:", sendError);
+      }
+    }
+  }
+
+  function generateRandomString() {
+    return window.btoa(Math.random()).slice(0, 20);
+  }
+  function generateOrderId() {
+    return crypto.randomUUID();
+  }
+
+
+</script>
+</body>
+</html>

--- a/com.spoticket.payment/src/main/resources/templates/success.html
+++ b/com.spoticket.payment/src/main/resources/templates/success.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="https://static.toss.im/icons/png/4x/icon-toss-logo.png" />
+  <link rel="stylesheet" type="text/css" href="/css/style.css" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>토스페이먼츠 샘플 프로젝트</title>
+</head>
+
+<body>
+<div class="box_section" style="width: 600px">
+  <img width="100px" src="https://static.toss.im/illusts/check-blue-spot-ending-frame.png" />
+  <h2>결제를 완료했어요</h2>
+
+  <div class="p-grid typography--p" style="margin-top: 50px">
+    <div class="p-grid-col text--left"><b>결제금액</b></div>
+    <div class="p-grid-col text--right" id="amount"></div>
+  </div>
+  <div class="p-grid typography--p" style="margin-top: 10px">
+    <div class="p-grid-col text--left"><b>주문번호</b></div>
+    <div class="p-grid-col text--right" id="orderId"></div>
+  </div>
+  <div class="p-grid typography--p" style="margin-top: 10px">
+    <div class="p-grid-col text--left"><b>paymentKey</b></div>
+    <div class="p-grid-col text--right" id="paymentKey" style="white-space: initial; width: 250px"></div>
+  </div>
+  <div class="p-grid" style="margin-top: 30px">
+    <button class="button p-grid-col5" onclick="location.href='https://docs.tosspayments.com/guides/v2/payment-widget/integration';">연동 문서</button>
+    <button class="button p-grid-col5" onclick="location.href='https://discord.gg/A4fRFXQhRu';" style="background-color: #e8f3ff; color: #1b64da">실시간 문의</button>
+  </div>
+</div>
+
+<div class="box_section" style="width: 600px; text-align: left">
+  <b>Response Data :</b>
+  <div id="response" style="white-space: initial"></div>
+</div>
+
+<script>
+  // 쿼리 파라미터 값을 서버로 전달해 결제 요청할 때 보낸 데이터와 동일한지 반드시 확인하세요.
+  // 클라이언트에서 결제 금액을 조작하는 행위를 방지할 수 있습니다.
+  const urlParams = new URLSearchParams(window.location.search);
+
+  // 서버로 결제 승인에 필요한 결제 정보를 보내세요.
+  async function confirm() {
+    var requestData = {
+      paymentKey: urlParams.get("paymentKey"),
+      orderId: urlParams.get("orderId"),
+      amount: urlParams.get("amount"),
+    };
+
+    const response = await fetch("/api/v1/payments/confirm", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestData),
+    });
+
+    const json = await response.json();
+
+    if (!response.ok) {
+      throw { message: json.message, code: json.code };
+    }
+
+    return json;
+  }
+
+  confirm()
+  .then(function (data) {
+    // TODO: 결제 승인에 성공했을 경우 UI 처리 로직을 구현하세요.
+    document.getElementById("response").innerHTML = `<pre>${JSON.stringify(data, null, 4)}</pre>`;
+  })
+  .catch(async (err) => {
+    // TODO: 결제 승인에 실패했을 경우 처리 로직을 구현하세요.
+    try {
+      await fetch("/api/v1/payments/fail", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          paymentKey: urlParams.get("paymentKey"),
+          orderId: urlParams.get("orderId"),
+          message: err.message,
+          code: err.code
+        })
+      });
+    } catch (failError) {
+      console.error("Failed to send failure information:", failError);
+    }
+    window.location.href = `/payment/fail?message=${encodeURIComponent(err.message)}&code=${encodeURIComponent(err.code)}`;
+  });
+
+  const paymentKeyElement = document.getElementById("paymentKey");
+  const orderIdElement = document.getElementById("orderId");
+  const amountElement = document.getElementById("amount");
+
+  orderIdElement.textContent = urlParams.get("orderId");
+  amountElement.textContent = urlParams.get("amount") + "원";
+  paymentKeyElement.textContent = urlParams.get("paymentKey");
+</script>
+</body>


### PR DESCRIPTION
# PR 제목

#30 결제 서비스 토스 API 연동 및 엔티티 수정

## 개요

주문이 생성되면 토스 api 연결을 통해서 결제가 가능하게 만들 예정이였으나..
주문과 결제를 논리적으로 분리하여 아직 연결이 되지 않아 html 코드내에 임시로 주문 데이터를 생성하였습니다.

## 변경 사항
[]결제 엔티티 수정
[]결제 내역 엔티티 수정
[]토스 api 연결


## 스크린샷 (선택사항)
<!-- UI 변경사항을 보여주는 스크린샷 -->

## 특이 사항
아직 주문과 결제 사이에 연동이 되지 않았습니다. 